### PR TITLE
adding line to cleanup debconf warnings during docker image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@ FROM ros:melodic-ros-base-bionic
 # USE BASH
 SHELL ["/bin/bash", "-c"]
 
+# RUN LINE BELOW TO REMOVE debconf ERRORS (MUST RUN BEFORE ANY apt-get CALLS)
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+
 RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends apt-utils
 
 # slam_toolbox


### PR DESCRIPTION
Thanks for the Dockerfile!  I noticed when building, I would get some gnarly debconf warnings.  This PR adds a step to cleanup these warnings.  Verified on:

- Bionic 18.04
- Docker version 18.09.7, build 2d0083d