### PR TITLE
create input for scan topic selection

### DIFF
--- a/config/mapper_params_lifelong.yaml
+++ b/config/mapper_params_lifelong.yaml
@@ -18,6 +18,7 @@ ceres_loss_function: None
 odom_frame: odom
 map_frame: map
 base_frame: base_footprint
+scan_topic: /scan
 mode: mapping
 
 # lifelong params

--- a/config/mapper_params_localization.yaml
+++ b/config/mapper_params_localization.yaml
@@ -18,6 +18,7 @@ ceres_loss_function: None
 odom_frame: odom
 map_frame: map
 base_frame: base_footprint
+scan_topic: /scan
 mode: mapping #localization
 
 # if you'd like to start localizing on bringup in a map and pose

--- a/config/mapper_params_offline.yaml
+++ b/config/mapper_params_offline.yaml
@@ -18,6 +18,7 @@ ceres_loss_function: None
 odom_frame: odom
 map_frame: map
 base_frame: base_link
+scan_topic: /scan
 mode: mapping #localization
 debug_logging: false
 throttle_scans: 1

--- a/config/mapper_params_online_async.yaml
+++ b/config/mapper_params_online_async.yaml
@@ -18,6 +18,7 @@ ceres_loss_function: None
 odom_frame: odom
 map_frame: map
 base_frame: base_footprint
+scan_topic: /scan
 mode: mapping #localization
 
 # if you'd like to immediately start continuing a map at a given pose

--- a/config/mapper_params_online_sync.yaml
+++ b/config/mapper_params_online_sync.yaml
@@ -18,6 +18,7 @@ ceres_loss_function: None
 odom_frame: odom
 map_frame: map
 base_frame: base_footprint
+scan_topic: /scan
 mode: mapping #localization
 
 # if you'd like to immediately start continuing a map at a given pose

--- a/include/slam_toolbox/slam_toolbox_common.hpp
+++ b/include/slam_toolbox/slam_toolbox_common.hpp
@@ -109,7 +109,7 @@ protected:
   ros::ServiceServer ssMap_, ssPauseMeasurements_, ssSerialize_, ssDesserialize_;
 
   // Storage for ROS parameters
-  std::string odom_frame_, map_frame_, base_frame_, map_name_;
+  std::string odom_frame_, map_frame_, base_frame_, map_name_, scan_topic_;
   ros::Duration transform_timeout_, tf_buffer_dur_, minimum_time_interval_;
   int throttle_scans_;
 

--- a/src/slam_toolbox_common.cpp
+++ b/src/slam_toolbox_common.cpp
@@ -114,6 +114,7 @@ void SlamToolbox::setParams(ros::NodeHandle& private_nh)
   private_nh.param("base_frame", base_frame_, std::string("base_footprint"));
   private_nh.param("resolution", resolution_, 0.05);
   private_nh.param("map_name", map_name_, std::string("/map"));
+  private_nh.param("scan_topic", scan_topic_, std::string("/scan"));
   private_nh.param("throttle_scans", throttle_scans_, 1);
   private_nh.param("enable_interactive_mode", enable_interactive_mode_, false);
 
@@ -152,7 +153,7 @@ void SlamToolbox::setROSInterfaces(ros::NodeHandle& node)
   ssPauseMeasurements_ = node.advertiseService("pause_new_measurements", &SlamToolbox::pauseNewMeasurementsCallback, this);
   ssSerialize_ = node.advertiseService("serialize_map", &SlamToolbox::serializePoseGraphCallback, this);
   ssDesserialize_ = node.advertiseService("deserialize_map", &SlamToolbox::deserializePoseGraphCallback, this);
-  scan_filter_sub_ = std::make_unique<message_filters::Subscriber<sensor_msgs::LaserScan> >(node, "/scan", 5);
+  scan_filter_sub_ = std::make_unique<message_filters::Subscriber<sensor_msgs::LaserScan> >(node, scan_topic_, 5);
   scan_filter_ = std::make_unique<tf2_ros::MessageFilter<sensor_msgs::LaserScan> >(*scan_filter_sub_, *tf_, odom_frame_, 5, node);
   scan_filter_->registerCallback(boost::bind(&SlamToolbox::laserCallback, this, _1));
 }


### PR DESCRIPTION
As a user, I wanted to be able to specify a custom scan topic.  My application required pre-filtering of the raw scan data before SLAM processing, and this PR allowed me to use the output of my scan filtering node.  Default behavior is unchanged: the default scan topic is still `/scan`.