### PR TITLE
save pose graph when merging map

### DIFF
--- a/slam_toolbox/include/slam_toolbox/merge_maps_kinematic.hpp
+++ b/slam_toolbox/include/slam_toolbox/merge_maps_kinematic.hpp
@@ -37,6 +37,7 @@
 #include "tf2/LinearMath/Matrix3x3.h"
 #include "tf2_geometry_msgs/tf2_geometry_msgs.h"
 #include "tf2/utils.h"
+#include "slam_toolbox/snap_utils.hpp"
 
 #include "karto_sdk/Mapper.h"
 #include "slam_toolbox/toolbox_types.hpp"

--- a/slam_toolbox/rviz_plugin/slam_toolbox_rviz_plugin.cpp
+++ b/slam_toolbox/rviz_plugin/slam_toolbox_rviz_plugin.cpp
@@ -142,6 +142,7 @@ SlamToolboxPlugin::SlamToolboxPlugin(QWidget* parent):
   _line5 = new QLineEdit();
   _line6 = new QLineEdit();
   _line7 = new QLineEdit();
+  _line8 = new QLineEdit();
 
   _button1->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
   _button2->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
@@ -160,6 +161,8 @@ SlamToolboxPlugin::SlamToolboxPlugin(QWidget* parent):
   _line5->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
   _line6->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
   _line7->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+  _line8->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+
 
   _hbox1->addWidget(_check1);
   _hbox1->addWidget(_label1);
@@ -178,6 +181,7 @@ SlamToolboxPlugin::SlamToolboxPlugin(QWidget* parent):
   _hbox5->addWidget(_line2);
 
   _hbox6->addWidget(_button6);
+  _hbox6->addWidget(_line8);
 
   _hbox7->addWidget(_button7);
   _hbox7->addWidget(_line3);
@@ -293,6 +297,7 @@ void SlamToolboxPlugin::GenerateMap()
 /*****************************************************************************/
 {
   slam_toolbox_msgs::MergeMaps msg;
+  msg.request.filename = _line8->text().toStdString();
   if (!_merge.call(msg))
   {
     ROS_WARN("MergeMaps: Failed to merge maps, is service running?");

--- a/slam_toolbox/rviz_plugin/slam_toolbox_rviz_plugin.h
+++ b/slam_toolbox/rviz_plugin/slam_toolbox_rviz_plugin.h
@@ -116,6 +116,7 @@ protected:
   QLineEdit* _line5;
   QLineEdit* _line6;
   QLineEdit* _line7;
+  QLineEdit* _line8;
 
   QCheckBox* _check1;
   QCheckBox* _check2;

--- a/slam_toolbox/src/merge_maps_kinematic.cpp
+++ b/slam_toolbox/src/merge_maps_kinematic.cpp
@@ -253,7 +253,7 @@ bool MergeMapsKinematic::mergeMapCallback(
       transformed_scans.push_back((*iter));
 
       if (iter == it_LRV->begin() && id != 1) {
-        processed = merged_mapper->ProcessAgainstNodesNearBy (*iter);
+        processed = merged_mapper->ProcessAgainstNodesNearBy(*iter);
       }
       else {
         merged_mapper->Process(*iter);

--- a/slam_toolbox/src/merge_maps_kinematic.cpp
+++ b/slam_toolbox/src/merge_maps_kinematic.cpp
@@ -239,7 +239,6 @@ bool MergeMapsKinematic::mergeMapCallback(
 
   // transform all the scans into the new global map coordinates 
   int id = 0;
-  bool processed = false;
   karto::LocalizedRangeScanVector transformed_scans;
   for(LocalizedRangeScansVecIt it_LRV = scans_vec_.begin();
     it_LRV != scans_vec_.end(); ++it_LRV)
@@ -253,7 +252,7 @@ bool MergeMapsKinematic::mergeMapCallback(
       transformed_scans.push_back((*iter));
 
       if (iter == it_LRV->begin() && id != 1) {
-        processed = merged_mapper->ProcessAgainstNodesNearBy(*iter);
+        merged_mapper->ProcessAgainstNodesNearBy(*iter);
       }
       else {
         merged_mapper->Process(*iter);

--- a/slam_toolbox/src/merge_maps_kinematic.cpp
+++ b/slam_toolbox/src/merge_maps_kinematic.cpp
@@ -294,6 +294,11 @@ bool MergeMapsKinematic::mergeMapCallback(
   {
     ROS_INFO("save pose graph as \"mergedmap\" ");
     filename = "mergedmap";
+    
+  }
+  if (snap_utils::isInSnap())
+  {
+    filename = snap_utils::getSnapPath() + std::string("/") + filename;
   }
   serialization::write(filename, *merged_mapper, *merged_dataset);
 }

--- a/slam_toolbox/src/merge_maps_kinematic.cpp
+++ b/slam_toolbox/src/merge_maps_kinematic.cpp
@@ -234,9 +234,12 @@ bool MergeMapsKinematic::mergeMapCallback(
 /*****************************************************************************/
 {
   ROS_INFO("Merging maps!");
+  std::unique_ptr<karto::Mapper> merged_mapper = std::make_unique<karto::Mapper>();
+  std::unique_ptr<karto::Dataset> merged_dataset = std::make_unique<karto::Dataset>();
 
   // transform all the scans into the new global map coordinates 
   int id = 0;
+  bool processed = false;
   karto::LocalizedRangeScanVector transformed_scans;
   for(LocalizedRangeScansVecIt it_LRV = scans_vec_.begin();
     it_LRV != scans_vec_.end(); ++it_LRV)
@@ -248,8 +251,24 @@ bool MergeMapsKinematic::mergeMapCallback(
       tf2::Transform submap_correction = submap_marker_transform_[id];
       transformScan(iter, submap_correction);
       transformed_scans.push_back((*iter));
+
+      if (iter == it_LRV->begin() && id != 1){
+      processed = merged_mapper -> ProcessAgainstNodesNearBy (*iter);
+      }
+      else {
+      merged_mapper -> Process(*iter);
+      }
+
     }
   }
+  
+  std::vector<std::unique_ptr<karto::Dataset> >::iterator it;
+  for (it = dataset_vec_.begin(); it != dataset_vec_.end(); ++it){
+      karto::LaserRangeFinder* laser = dynamic_cast<karto::LaserRangeFinder*>(
+        it->get()->GetLasers()[0]);
+      merged_dataset->Add(laser, true);
+  }
+
 
   // create the map
   nav_msgs::GetMap::Response map;
@@ -267,6 +286,10 @@ bool MergeMapsKinematic::mergeMapCallback(
   map.map.header.frame_id = "map";
   sstS_[0].publish(map.map);
   sstmS_[0].publish(map.map.info);
+
+  merged_mapper -> GetGraph()->CorrectPoses();
+  std::string filename = req.filename;
+  serialization::write(filename, *merged_mapper, *merged_dataset);
 }
 
 /*****************************************************************************/

--- a/slam_toolbox/src/merge_maps_kinematic.cpp
+++ b/slam_toolbox/src/merge_maps_kinematic.cpp
@@ -252,11 +252,11 @@ bool MergeMapsKinematic::mergeMapCallback(
       transformScan(iter, submap_correction);
       transformed_scans.push_back((*iter));
 
-      if (iter == it_LRV->begin() && id != 1){
-      processed = merged_mapper -> ProcessAgainstNodesNearBy (*iter);
+      if (iter == it_LRV->begin() && id != 1) {
+        processed = merged_mapper->ProcessAgainstNodesNearBy (*iter);
       }
       else {
-      merged_mapper -> Process(*iter);
+        merged_mapper->Process(*iter);
       }
 
     }
@@ -287,8 +287,14 @@ bool MergeMapsKinematic::mergeMapCallback(
   sstS_[0].publish(map.map);
   sstmS_[0].publish(map.map.info);
 
-  merged_mapper -> GetGraph()->CorrectPoses();
+  merged_mapper->GetGraph()->CorrectPoses();
   std::string filename = req.filename;
+  
+  if (filename.empty())
+  {
+    ROS_INFO("save pose graph as \"mergedmap\" ");
+    filename = "mergedmap";
+  }
   serialization::write(filename, *merged_mapper, *merged_dataset);
 }
 

--- a/slam_toolbox_msgs/srv/MergeMaps.srv
+++ b/slam_toolbox_msgs/srv/MergeMaps.srv
@@ -1,2 +1,2 @@
-
+string filename
 ---


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   |  |
| Primary OS tested on | (Ubuntu) |
| Robotic platform tested on | ( customized hardware ) |

---



## Description of contribution in a few bullet points

* when generate merged map , also generate merged posegraph, but I don't update rviz gui, so only indicate the file name with command line

## Description of documentation updates required from your changes


* rosservice call /map_merging/merge_submaps "filename: ''the name you want" 


---

## Future work that may be required in bullet points

* When merge pose graph, it should work as lifelong to decay old node.
