### PR TITLE
Add use_sim_time supprt to online sync/async slam_toolbox node

### DIFF
--- a/launch/online_async_launch.py
+++ b/launch/online_async_launch.py
@@ -1,17 +1,31 @@
 from launch import LaunchDescription
-import launch_ros.actions
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
 from ament_index_python.packages import get_package_share_directory
 
 
 def generate_launch_description():
-    return LaunchDescription([
-        launch_ros.actions.Node(
-          parameters=[
-            get_package_share_directory("slam_toolbox") + '/config/mapper_params_online_async.yaml'
-          ],
-          package='slam_toolbox',
-          node_executable='async_slam_toolbox_node',
-          name='slam_toolbox',
-          output='screen'
-        )
-    ])
+    use_sim_time = LaunchConfiguration('use_sim_time')
+
+    declare_use_sim_time_argument = DeclareLaunchArgument(
+        'use_sim_time',
+        default_value='true',
+        description='Use simulation/Gazebo clock')
+
+    start_async_slam_toolbox_node = Node(
+        parameters=[
+          get_package_share_directory("slam_toolbox") + '/config/mapper_params_online_async.yaml',
+          {'use_sim_time': use_sim_time}
+        ],
+        package='slam_toolbox',
+        node_executable='async_slam_toolbox_node',
+        name='slam_toolbox',
+        output='screen')
+
+    ld = LaunchDescription()
+
+    ld.add_action(declare_use_sim_time_argument)
+    ld.add_action(start_async_slam_toolbox_node)
+
+    return ld

--- a/launch/online_sync_launch.py
+++ b/launch/online_sync_launch.py
@@ -1,17 +1,31 @@
 from launch import LaunchDescription
-import launch_ros.actions
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
 from ament_index_python.packages import get_package_share_directory
 
 
 def generate_launch_description():
-    return LaunchDescription([
-        launch_ros.actions.Node(
-          parameters=[
-            get_package_share_directory("slam_toolbox") + '/config/mapper_params_online_sync.yaml'
-          ],
-          package='slam_toolbox',
-          node_executable='sync_slam_toolbox_node',
-          name='slam_toolbox',
-          output='screen'
-        )
-    ])
+    use_sim_time = LaunchConfiguration('use_sim_time')
+
+    declare_use_sim_time_argument = DeclareLaunchArgument(
+        'use_sim_time',
+        default_value='true',
+        description='Use simulation/Gazebo clock')
+
+    start_sync_slam_toolbox_node = Node(
+        parameters=[
+          get_package_share_directory("slam_toolbox") + '/config/mapper_params_online_sync.yaml',
+          {'use_sim_time': use_sim_time}
+        ],
+        package='slam_toolbox',
+        node_executable='sync_slam_toolbox_node',
+        name='slam_toolbox',
+        output='screen')
+
+    ld = LaunchDescription()
+
+    ld.add_action(declare_use_sim_time_argument)
+    ld.add_action(start_sync_slam_toolbox_node)
+
+    return ld


### PR DESCRIPTION
Add the support of `use_sim_time` parameter to `online_sync_launch.py` and `online_async_launch.py`. This is required for https://github.com/ros-planning/navigation2/issues/1630 to have smooth SLAM running with Gazebo.