### PR TITLE
Add transform_timeout support

### DIFF
--- a/launch/online_async_launch.py
+++ b/launch/online_async_launch.py
@@ -3,19 +3,36 @@ from launch.actions import DeclareLaunchArgument
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 from ament_index_python.packages import get_package_share_directory
+from nav2_common.launch import RewrittenYaml
 
 
 def generate_launch_description():
     use_sim_time = LaunchConfiguration('use_sim_time')
+    transform_timeout = LaunchConfiguration('transform_timeout')
+    params_file = get_package_share_directory("slam_toolbox") +\
+        '/config/mapper_params_online_sync.yaml';
+
+    param_substitutions = {
+        'transform_timeout': transform_timeout}
+
+    reconfigured_params = RewrittenYaml(
+            source_file=params_file,
+            param_rewrites=param_substitutions,
+            convert_types=True)
 
     declare_use_sim_time_argument = DeclareLaunchArgument(
         'use_sim_time',
         default_value='true',
         description='Use simulation/Gazebo clock')
 
+    declare_transform_timeout_argument = DeclareLaunchArgument(
+        'transform_timeout',
+        default_value='0.2',
+        description='Ahead time of publishing TF messages')
+
     start_async_slam_toolbox_node = Node(
         parameters=[
-          get_package_share_directory("slam_toolbox") + '/config/mapper_params_online_async.yaml',
+          reconfigured_params,
           {'use_sim_time': use_sim_time}
         ],
         package='slam_toolbox',
@@ -26,6 +43,7 @@ def generate_launch_description():
     ld = LaunchDescription()
 
     ld.add_action(declare_use_sim_time_argument)
+    ld.add_action(declare_transform_timeout_argument)
     ld.add_action(start_async_slam_toolbox_node)
 
     return ld

--- a/launch/online_async_launch.py
+++ b/launch/online_async_launch.py
@@ -1,16 +1,17 @@
+from ament_index_python.packages import get_package_share_directory
+
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
-from ament_index_python.packages import get_package_share_directory
 from nav2_common.launch import RewrittenYaml
 
 
 def generate_launch_description():
     use_sim_time = LaunchConfiguration('use_sim_time')
     transform_timeout = LaunchConfiguration('transform_timeout')
-    params_file = get_package_share_directory("slam_toolbox") +\
-        '/config/mapper_params_online_sync.yaml';
+    params_file = get_package_share_directory('slam_toolbox') +\
+        '/config/mapper_params_online_sync.yaml'
 
     param_substitutions = {
         'transform_timeout': transform_timeout}

--- a/launch/online_sync_launch.py
+++ b/launch/online_sync_launch.py
@@ -1,16 +1,17 @@
+from ament_index_python.packages import get_package_share_directory
+
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
-from ament_index_python.packages import get_package_share_directory
 from nav2_common.launch import RewrittenYaml
 
 
 def generate_launch_description():
     use_sim_time = LaunchConfiguration('use_sim_time')
     transform_timeout = LaunchConfiguration('transform_timeout')
-    params_file = get_package_share_directory("slam_toolbox") +\
-        '/config/mapper_params_online_sync.yaml';
+    params_file = get_package_share_directory('slam_toolbox') +\
+        '/config/mapper_params_online_sync.yaml'
 
     param_substitutions = {
         'transform_timeout': transform_timeout}

--- a/launch/online_sync_launch.py
+++ b/launch/online_sync_launch.py
@@ -3,19 +3,36 @@ from launch.actions import DeclareLaunchArgument
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 from ament_index_python.packages import get_package_share_directory
+from nav2_common.launch import RewrittenYaml
 
 
 def generate_launch_description():
     use_sim_time = LaunchConfiguration('use_sim_time')
+    transform_timeout = LaunchConfiguration('transform_timeout')
+    params_file = get_package_share_directory("slam_toolbox") +\
+        '/config/mapper_params_online_sync.yaml';
+
+    param_substitutions = {
+        'transform_timeout': transform_timeout}
+
+    reconfigured_params = RewrittenYaml(
+            source_file=params_file,
+            param_rewrites=param_substitutions,
+            convert_types=True)
 
     declare_use_sim_time_argument = DeclareLaunchArgument(
         'use_sim_time',
         default_value='true',
         description='Use simulation/Gazebo clock')
 
+    declare_transform_timeout_argument = DeclareLaunchArgument(
+        'transform_timeout',
+        default_value='0.2',
+        description='Ahead time of publishing TF messages')
+
     start_sync_slam_toolbox_node = Node(
         parameters=[
-          get_package_share_directory("slam_toolbox") + '/config/mapper_params_online_sync.yaml',
+          reconfigured_params,
           {'use_sim_time': use_sim_time}
         ],
         package='slam_toolbox',
@@ -26,6 +43,7 @@ def generate_launch_description():
     ld = LaunchDescription()
 
     ld.add_action(declare_use_sim_time_argument)
+    ld.add_action(declare_transform_timeout_argument)
     ld.add_action(start_sync_slam_toolbox_node)
 
     return ld


### PR DESCRIPTION
Add the support `transform_timeout` parameter to `online_sync_launch.py` and `online_async_launch.py`. This is required as a part of workaround for Issue No.3 mentioned in https://github.com/ros-planning/navigation2/issues/1630#issuecomment-632719758

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | https://github.com/ros-planning/navigation2/issues/1630 |
| PR(s) this depends on   | https://github.com/ros-planning/navigation2/pull/1768 |
| Primary OS tested on | Ubuntu 20.04 |
| Robotic platform tested on | Gazebo simulation of TB3 waffle |