### PR TITLE
Bump to 1.5.3 due to github merge failure to properly handle version updates

### DIFF
--- a/slam_toolbox/package.xml
+++ b/slam_toolbox/package.xml
@@ -3,7 +3,7 @@
   <description>
      This package provides a sped up improved slam karto with updated SDK and visualization and modification toolsets
   </description>
-  <version>1.5.1</version>
+  <version>1.5.3</version>
   <maintainer email="stevenmacenski@gmail.com">Steve Macenski</maintainer>
   <author>Steve Macenski</author>
   <license>LGPL</license>

--- a/slam_toolbox_msgs/package.xml
+++ b/slam_toolbox_msgs/package.xml
@@ -3,7 +3,7 @@
   <description>
      This package provides a sped up improved slam karto with updated SDK and visualization and modification toolsets
   </description>
-  <version>1.5.2</version>
+  <version>1.5.3</version>
   <maintainer email="stevenmacenski@gmail.com">Steve Macenski</maintainer>
   <author>Steve Macenski</author>
   <license>LGPL</license>

--- a/slam_toolbox_rviz/package.xml
+++ b/slam_toolbox_rviz/package.xml
@@ -3,7 +3,7 @@
   <description>
      This package provides a sped up improved slam karto with updated SDK and visualization and modification toolsets
   </description>
-  <version>1.5.2</version>
+  <version>1.5.3</version>
   <maintainer email="stevenmacenski@gmail.com">Steve Macenski</maintainer>
   <author>Steve Macenski</author>
   <license>LGPL</license>


### PR DESCRIPTION
One of the packages didn't resolve conflicts correctly automatically so the 1.5.2 didn't get updated from 1.5.1 needed for release
