### PR TITLE
Fixed the name of the map_saver script used by the /save_map service

### DIFF
--- a/src/map_saver.cpp
+++ b/src/map_saver.cpp
@@ -60,11 +60,11 @@ bool MapSaver::saveMapCallback(
   if (name != "") {
     RCLCPP_INFO(node_->get_logger(),
       "SlamToolbox: Saving map as %s.", name.c_str());
-    int rc = system(("ros2 run nav2_map_server map_saver -f " + name).c_str());
+    int rc = system(("ros2 run nav2_map_server map_saver_cli -f " + name).c_str());
   } else {
     RCLCPP_INFO(node_->get_logger(),
       "SlamToolbox: Saving map in current directory.");
-    int rc = system("ros2 run nav2_map_server map_saver");
+    int rc = system("ros2 run nav2_map_server map_saver_cli");
   }
 
   rclcpp::sleep_for(std::chrono::seconds(1));


### PR DESCRIPTION
## Basic Info

| Info | |
| ------ | ----------- |
| Ticket(s) this addresses   | #216 |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | turtlebot3 simulation |

---

## Description of contribution in a few bullet points

Updated the name of the map saver script to align with updates made on nav2.
