### PR TITLE
fix for typo in distance calculation (getX-getY)

### DIFF
--- a/slam_toolbox/src/slam_toolbox_common.cpp
+++ b/slam_toolbox/src/slam_toolbox_common.cpp
@@ -447,7 +447,6 @@ bool SlamToolbox::shouldProcessScan(
   // check moved enough, within 10% for correction error
   const double sq_dist_to_last_accepted_pose = last_pose.SquaredDistance(pose);
 
-  // TODO: Accept scan if robot rotated on the spot, but did not translate (e.g. while using a non 360-deg scanner)
   if(sq_dist_to_last_accepted_pose < 0.8 * dist_thresh_sq || scan->header.seq < 5)
   {
     return false;


### PR DESCRIPTION
bool SlamToolbox::shouldProcessScan:

  const double dist2 = fabs((last_pose.GetX() - pose.GetX())*(last_pose.GetX() - 
    pose.GetX()) + (last_pose.GetY() - pose.GetY())*
    **(last_pose.GetX() - pose.GetY()));**

Last element looks like a copy/paste error that leads to a wrong distance calculation so that all scans would be accepted and getParamMinimumTravelDistance ignored. 

In the same function, scans from a rotating, but not translating robot should also be accepted. 

