### PR TITLE
Update slam_toolbox_rviz_plugin.h

### DIFF
--- a/slam_toolbox_rviz/src/slam_toolbox_rviz_plugin.h
+++ b/slam_toolbox_rviz/src/slam_toolbox_rviz_plugin.h
@@ -83,7 +83,6 @@ protected Q_SLOTS:
   void SaveMap();
   void ClearQueue();
   void InteractiveCb(int state);
-  void PauseProcessingCb(int state);
   void PauseMeasurementsCb(int state);
   void FirstNodeMatchCb();
   void PoseEstMatchCb();


### PR DESCRIPTION
Fix error:
```
Undefined symbols for architecture x86_64:
  "slam_toolbox::SlamToolboxPlugin::PauseProcessingCb(int)", referenced from:
      slam_toolbox::SlamToolboxPlugin::qt_static_metacall(QObject*, QMetaObject::Call, int, void**) in moc_slam_toolbox_rviz_plugin.cxx.o
ld: symbol(s) not found for architecture x86_64
```
