### PR TITLE
Don't overwrite system/command line CMAKE_CXX_FLAGS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(slam_toolbox)
 add_compile_options(-std=c++14)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/CMake/")
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/lib/karto_sdk/cmake)
-set(CMAKE_CXX_FLAGS "-fpermissive -std=c++14")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fpermissive -std=c++14")
 set(CMAKE_CXX_STANDARD 14)
 
 find_package(ament_cmake REQUIRED)


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (none) |
| Primary OS tested on | Fedora Linux |
| Robotic platform tested on | (none) |

---

## Description of contribution in a few bullet points

Rather than overwriting the `CMAKE_CXX_FLAGS` that may have been supplied by the system, environment, or command line arguments, append the additional flags required by the project. This will allow system-supplied flags to be used, as well as enable the `--cmake-args` option for colcon to supply flags.

---

## Description of documentation updates required from your changes

(none)

---

## Future work that may be required in bullet points

(none)
