### PR TITLE
Bypass transform publish if transform from base_link to odom failed

### DIFF
--- a/slam_toolbox/src/slam_toolbox_common.cpp
+++ b/slam_toolbox/src/slam_toolbox_common.cpp
@@ -356,7 +356,7 @@ tf2::Stamped<tf2::Transform> SlamToolbox::setTransformFromPoses(
   catch(tf2::TransformException& e)
   {
     ROS_ERROR("Transform from base_link to odom failed: %s", e.what());
-    odom_to_map.setIdentity();
+    return odom_to_map;
   }
 
   // if we're continuing a previous session, we need to


### PR DESCRIPTION
In response to Issue #198: Instead of publishing an "Identity" transform if the base_link to odom transform fails, just skip this update.
While this is ultimately covering for likely bigger problem with the system (i.e. insufficient CPU power or out of spec settings), it produces a less catastrophic side effect.