### PR TITLE
Allow init from rviz initial pose

### DIFF
--- a/slam_toolbox_rviz/src/slam_toolbox_rviz_plugin.cpp
+++ b/slam_toolbox_rviz/src/slam_toolbox_rviz_plugin.cpp
@@ -236,7 +236,7 @@ void SlamToolboxPlugin::InitialPoseCallback(const geometry_msgs::PoseWithCovaria
 /*****************************************************************************/
 {
   _match_type = PROCESS_NEAR_REGION_CMT;
-  ROS_INFO("Processing at current pose estimate selected.");
+  ROS_INFO("Setting initial pose from rviz; you can now deserialize a map given that pose.");
   _radio2->setChecked(true);
   _line5->setText(QString::number(msg->pose.pose.position.x, 'f', 2));
   _line6->setText(QString::number(msg->pose.pose.position.y, 'f', 2));
@@ -249,7 +249,6 @@ void SlamToolboxPlugin::InitialPoseCallback(const geometry_msgs::PoseWithCovaria
   double roll, pitch, yaw;
   m.getRPY(roll, pitch, yaw);
   _line7->setText(QString::number(yaw, 'f', 2));
-  DeserializeMap();
 }
 
 /*****************************************************************************/

--- a/slam_toolbox_rviz/src/slam_toolbox_rviz_plugin.h
+++ b/slam_toolbox_rviz/src/slam_toolbox_rviz_plugin.h
@@ -40,6 +40,7 @@
 #include <thread>
 
 // msgs
+#include <geometry_msgs/PoseWithCovarianceStamped.h>
 #include "slam_toolbox_msgs/AddSubmap.h"
 #include "slam_toolbox_msgs/Clear.h"
 #include "slam_toolbox_msgs/ClearQueue.h"
@@ -144,6 +145,9 @@ protected:
   QFrame* _line;
 
   ros::ServiceClient _clearChanges, _saveChanges, _saveMap, _clearQueue, _interactive, _pause_measurements, _load_submap_for_merging, _merge, _serialize, _load_map;
+  ros::Subscriber _initialposeSub;
+
+  void InitialPoseCallback(const geometry_msgs::PoseWithCovarianceStamped::ConstPtr& pose);
 
   std::thread* _thread;
 


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---
## Description of contribution in a few bullet points

* Added the ability to use the initial pose button in rviz in the online_sync / online_async modes.
* Fixed a crash of rviz when no pose estimate was entered
* This basically allows to easily continue previous mapping sessions
