### PR TITLE
Handle case for lidar with 1 degree resolution that goes from [-179,180] with 360 readings

### DIFF
--- a/src/laser_utils.cpp
+++ b/src/laser_utils.cpp
@@ -106,7 +106,7 @@ karto::LaserRangeFinder * LaserAssistant::makeLaser(const double & mountingYaw)
   laser->SetAngularResolution(scan_.angle_increment);
 
   bool is_360_lidar = false;
-  if (std::fabs(scan_.angle_max - scan_.angle_min - 2.0 * M_PI) < 1e-1) {
+  if (std::fabs(scan_.angle_max - scan_.angle_min - 2.0 * M_PI) < (scan_.angle_increment - (std::numeric_limits<float>::epsilon() * 2.0f*M_PI))) {
     is_360_lidar = true;
   }
 


### PR DESCRIPTION
The current 360 lidar check threshold will tell Karto that lasers with [(-PI+angle_increment),PI] scan range are 360 lidars, which leads Karto to look for (angle_max-angle_min)/angle_increment readings (without the +1 residual), which will not match the number of readings for this configuration (ex: Karto looks for 359 instead of 360 for 1 degree case.) This fixes compatibility for RPLIDAR in angle_compensate mode.  Works with patched RPLIDAR driver here: https://github.com/allenh1/rplidar_ros/pull/20.
