### PR TITLE
[Noetic] Fix build failure (#291)

### DIFF
--- a/slam_toolbox_rviz/CMakeLists.txt
+++ b/slam_toolbox_rviz/CMakeLists.txt
@@ -54,3 +54,5 @@ install(TARGETS ${PROJECT_NAME}
 install(FILES rviz_plugins.xml
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )
+
+add_dependencies(slam_toolbox_rviz slam_toolbox_msgs_generate_messages_cpp)


### PR DESCRIPTION
Adds working dependency on slam_toolbox_msgs to
slam_toolbox_rviz to ensure correct build order.

I am not a CMake expert, but I tested this several times on my system, both with and without the fix, reproducing the failure without, and successfully building with the fix.

I think this failure only affects Noetic, but I can double check if you think other branches need the fix too.