### PR TITLE
Various fixes

### DIFF
--- a/slam_toolbox/CMakeLists.txt
+++ b/slam_toolbox/CMakeLists.txt
@@ -5,7 +5,7 @@ add_compile_options(-std=c++17)
 set(CMAKE_BUILD_TYPE Release) #None, Debug, Release, RelWithDebInfo, MinSizeRel
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/CMake/")
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/lib/karto_sdk/cmake)
-set(CMAKE_CXX_FLAGS "-fpermissive -std=c++17")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fpermissive -std=c++17")
 
 #karto_sdk lib
 set(BUILD_SHARED_LIBS ON)
@@ -48,8 +48,7 @@ find_package(Boost REQUIRED system serialization filesystem thread)
 include_directories(include ${catkin_INCLUDE_DIRS} 
                             ${EIGEN3_INCLUDE_DIRS} 
                             ${CHOLMOD_INCLUDE_DIR}
-                            ${Boost_INCLUDE_DIR}
-                            ${BOOST_INCLUDE_DIRS}
+                            ${Boost_INCLUDE_DIRS}
                             ${TBB_INCLUDE_DIRS}
 )
 
@@ -58,7 +57,7 @@ add_definitions(${EIGEN3_DEFINITIONS})
 catkin_package(
     INCLUDE_DIRS
       include
-      ${BOOST_INCLUDE_DIRS}
+      ${Boost_INCLUDE_DIRS}
       ${EIGEN3_INCLUDE_DIRS}
       ${TBB_INCLUDE_DIRS}
     LIBRARIES
@@ -89,7 +88,6 @@ catkin_package(
 #### Ceres Plugin
 add_library(ceres_solver_plugin solvers/ceres_solver.cpp)
 target_link_libraries(ceres_solver_plugin ${catkin_LIBRARIES} 
-                                          ${CERES_INCLUDE_DIRS}
                                           ${CERES_LIBRARIES}
                                           ${Boost_LIBRARIES}
                                           ${TBB_LIBRARIES}

--- a/slam_toolbox/lib/karto_sdk/CMakeLists.txt
+++ b/slam_toolbox/lib/karto_sdk/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(karto_sdk)
 
 set(CMAKE_BUILD_TYPE Release) #None, Debug, Release, RelWithDebInfo, MinSizeRel
-set(CMAKE_CXX_FLAGS "-ftemplate-backtrace-limit=0") 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ftemplate-backtrace-limit=0")
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
 
 find_package(catkin REQUIRED)
@@ -24,7 +24,7 @@ catkin_package(
 
 add_definitions(${EIGEN3_DEFINITIONS})
 
-include_directories(include ${catkin_INCLUDE_DIRS} ${EIGEN3_INCLUDE_DIRS} ${TBB_INCLUDE_DIRS} ${Boost_INCLUDE_DIR})
+include_directories(include ${catkin_INCLUDE_DIRS} ${EIGEN3_INCLUDE_DIRS} ${TBB_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
 add_library(karto SHARED src/Karto.cpp src/Mapper.cpp)
 target_link_libraries(karto ${Boost_LIBRARIES} ${TBB_LIBRARIES})
 


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | N/A |
| Primary OS tested on | Linux+OSX |
| Robotic platform tested on | N/A |

---

We are currently building various ROS packages on conda. These fixes allow building slam-toolbox on conda, however they are generic fixes which should be included upstream (i.e. here). Specificially, `Boost_INCLUDE_DIRS` was wrongly referred to in various places and various ways (see https://cmake.org/cmake/help/v3.0/module/FindBoost.html); and the `CMAKE_CXX_FLAGS` were overridden without taking into account what was passed to them.

This probably needs fixing in various other branches, too - I'll leave this up to you guys.

## Description of contribution in a few bullet points

Fixes various cmake issues

## Description of documentation updates required from your changes

N/A

## Future work that may be required in bullet points

N/A