### PR TITLE
copying timestamp from ros-msg to LocalizedRangeScan

### DIFF
--- a/src/slam_toolbox_common.cpp
+++ b/src/slam_toolbox_common.cpp
@@ -456,6 +456,7 @@ LocalizedRangeScan * SlamToolbox::getLocalizedRangeScan(
     laser->GetName(), readings);
   range_scan->SetOdometricPose(transformed_pose);
   range_scan->SetCorrectedPose(transformed_pose);
+  range_scan->SetTime(rclcpp::Time(scan->header.stamp).nanoseconds()/1.e9);
   return range_scan;
 }
 


### PR DESCRIPTION
The LocalizedRangeScan (as its a SensorData) has a m_Time-member which is not filled when it is created in getLocalizedRangeScan. 