### PR TITLE
changed depricated node_executable to executable

### DIFF
--- a/launch/lifelong_launch.py
+++ b/launch/lifelong_launch.py
@@ -10,7 +10,7 @@ def generate_launch_description():
             get_package_share_directory("slam_toolbox") + '/config/mapper_params_lifelong.yaml'
           ],
           package='slam_toolbox',
-          node_executable='lifelong_slam_toolbox_node',
+          executable='lifelong_slam_toolbox_node',
           name='slam_toolbox',
           output='screen'
         )

--- a/launch/localization_launch.py
+++ b/launch/localization_launch.py
@@ -10,7 +10,7 @@ def generate_launch_description():
             get_package_share_directory("slam_toolbox") + '/config/mapper_params_localization.yaml'
           ],
           package='slam_toolbox',
-          node_executable='localization_slam_toolbox_node',
+          executable='localization_slam_toolbox_node',
           name='slam_toolbox',
           output='screen'
         )

--- a/launch/merge_maps_kinematic_launch.py
+++ b/launch/merge_maps_kinematic_launch.py
@@ -6,7 +6,7 @@ def generate_launch_description():
     return LaunchDescription([
         launch_ros.actions.Node(
             package='slam_toolbox',
-            node_executable='merge_maps_kinematic',
+            executable='merge_maps_kinematic',
             name='slam_toolbox',
             output='screen'
         )

--- a/launch/offline_launch.py
+++ b/launch/offline_launch.py
@@ -10,7 +10,7 @@ def generate_launch_description():
             get_package_share_directory("slam_toolbox") + '/config/mapper_params_offline.yaml'
           ],
           package='slam_toolbox',
-          node_executable='sync_slam_toolbox_node',
+          executable='sync_slam_toolbox_node',
           name='slam_toolbox',
           output='screen'
         )

--- a/launch/online_async_launch.py
+++ b/launch/online_async_launch.py
@@ -19,7 +19,7 @@ def generate_launch_description():
           {'use_sim_time': use_sim_time}
         ],
         package='slam_toolbox',
-        node_executable='async_slam_toolbox_node',
+        executable='async_slam_toolbox_node',
         name='slam_toolbox',
         output='screen')
 

--- a/launch/online_sync_launch.py
+++ b/launch/online_sync_launch.py
@@ -19,7 +19,7 @@ def generate_launch_description():
           {'use_sim_time': use_sim_time}
         ],
         package='slam_toolbox',
-        node_executable='sync_slam_toolbox_node',
+        executable='sync_slam_toolbox_node',
         name='slam_toolbox',
         output='screen')
 


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | No ticket |
| Primary OS tested on | Ubuntu 20.04 |
| Robotic platform tested on | - |

---

## Description of contribution in a few bullet points
In ROS 2 Foxy, the term `node_executable` is deprecated, and `executable` should be used instead. See warning when launching:

`foxy_ws/install/slam_toolbox/share/slam_toolbox/launch/merge_maps_kinematic_launch.py:7: UserWarning: The parameter 'node_executable' is deprecated, use 'executable' instead`

The change is described in the release notes of ROS 2 [Foxy](https://index.ros.org/doc/ros2/Releases/Release-Foxy-Fitzroy/#launch-ros)
It's a warning, so it's not code breaking, but I thought for the sake of cleanliness, it should still be updated.

## Description of documentation updates required from your changes
None (as far as I know of?)

---

## Future work that may be required in bullet points
No future work required.
