### PR TITLE
fix mutually exclusive mapping start pose (#319)

### DIFF
--- a/src/slam_toolbox_common.cpp
+++ b/src/slam_toolbox_common.cpp
@@ -300,8 +300,8 @@ bool SlamToolbox::shouldStartWithPoseGraph(
 {
   // if given a map to load at run time, do it.
   this->declare_parameter("map_file_name", std::string(""));
-  this->declare_parameter("map_start_pose", std::vector<double>());
-  this->declare_parameter("map_start_at_dock", false);
+  this->declare_parameter("map_start_pose");
+  this->declare_parameter("map_start_at_dock");
   filename = this->get_parameter("map_file_name").as_string();
   if (!filename.empty()) {
     std::vector<double> read_pose;
@@ -319,8 +319,15 @@ bool SlamToolbox::shouldStartWithPoseGraph(
         pose.y = read_pose[1];
         pose.theta = read_pose[2];
       }
-    } else {
+    } else if (this->get_parameter("map_start_at_dock", start_at_dock)) {
       start_at_dock = this->get_parameter("map_start_at_dock").as_bool();
+    } else {
+      start_at_dock = false;
+      RCLCPP_ERROR(get_logger(), "LocalizationSlamToolbox: Map starting "
+          "pose not specified. Starting at origin");
+      pose.x = 0.;
+      pose.y = 0.;
+      pose.theta = 0.;
     }
 
     return true;

--- a/src/slam_toolbox_common.cpp
+++ b/src/slam_toolbox_common.cpp
@@ -300,13 +300,13 @@ bool SlamToolbox::shouldStartWithPoseGraph(
 {
   // if given a map to load at run time, do it.
   this->declare_parameter("map_file_name", std::string(""));
-  auto read_pose_param = this->declare_parameter("map_start_pose");
-  auto start_at_dock_param = this->declare_parameter("map_start_at_dock");
+  auto map_start_pose = this->declare_parameter("map_start_pose");
+  auto map_start_at_dock = this->declare_parameter("map_start_at_dock");
   filename = this->get_parameter("map_file_name").as_string();
   if (!filename.empty()) {
     std::vector<double> read_pose;
-    if (read_pose_param.get_type() != rclcpp::ParameterType::PARAMETER_NOT_SET) {
-      read_pose = read_pose_param.get<std::vector<double>>();
+    if (map_start_pose.get_type() != rclcpp::ParameterType::PARAMETER_NOT_SET) {
+      read_pose = map_start_pose.get<std::vector<double>>();
       start_at_dock = false;
       if (read_pose.size() != 3) {
         RCLCPP_ERROR(get_logger(), "LocalizationSlamToolbox: Incorrect "
@@ -320,8 +320,8 @@ bool SlamToolbox::shouldStartWithPoseGraph(
         pose.y = read_pose[1];
         pose.theta = read_pose[2];
       }
-    } else if (start_at_dock_param.get_type() != rclcpp::ParameterType::PARAMETER_NOT_SET) {
-      start_at_dock = start_at_dock_param.get<bool>();
+    } else if (map_start_at_dock.get_type() != rclcpp::ParameterType::PARAMETER_NOT_SET) {
+      start_at_dock = map_start_at_dock.get<bool>();
     } else {
       RCLCPP_ERROR(get_logger(), "LocalizationSlamToolbox: Map starting "
           "pose not specified. Set either map_start_pose or map_start_at_dock.");

--- a/src/slam_toolbox_common.cpp
+++ b/src/slam_toolbox_common.cpp
@@ -300,12 +300,13 @@ bool SlamToolbox::shouldStartWithPoseGraph(
 {
   // if given a map to load at run time, do it.
   this->declare_parameter("map_file_name", std::string(""));
-  this->declare_parameter("map_start_pose");
-  this->declare_parameter("map_start_at_dock");
+  auto read_pose_param = this->declare_parameter("map_start_pose");
+  auto start_at_dock_param = this->declare_parameter("map_start_at_dock");
   filename = this->get_parameter("map_file_name").as_string();
   if (!filename.empty()) {
     std::vector<double> read_pose;
-    if (this->get_parameter("map_start_pose", read_pose)) {
+    if (read_pose_param.get_type() != rclcpp::ParameterType::PARAMETER_NOT_SET) {
+      read_pose = read_pose_param.get<std::vector<double>>();
       start_at_dock = false;
       if (read_pose.size() != 3) {
         RCLCPP_ERROR(get_logger(), "LocalizationSlamToolbox: Incorrect "
@@ -319,8 +320,8 @@ bool SlamToolbox::shouldStartWithPoseGraph(
         pose.y = read_pose[1];
         pose.theta = read_pose[2];
       }
-    } else if (this->get_parameter("map_start_at_dock", start_at_dock)) {
-      start_at_dock = this->get_parameter("map_start_at_dock").as_bool();
+    } else if (start_at_dock_param.get_type() != rclcpp::ParameterType::PARAMETER_NOT_SET) {
+      start_at_dock = start_at_dock_param.get<bool>();
     } else {
       RCLCPP_ERROR(get_logger(), "LocalizationSlamToolbox: Map starting "
           "pose not specified. Set either map_start_pose or map_start_at_dock.");

--- a/src/slam_toolbox_common.cpp
+++ b/src/slam_toolbox_common.cpp
@@ -322,12 +322,9 @@ bool SlamToolbox::shouldStartWithPoseGraph(
     } else if (this->get_parameter("map_start_at_dock", start_at_dock)) {
       start_at_dock = this->get_parameter("map_start_at_dock").as_bool();
     } else {
-      start_at_dock = false;
       RCLCPP_ERROR(get_logger(), "LocalizationSlamToolbox: Map starting "
-          "pose not specified. Starting at origin");
-      pose.x = 0.;
-      pose.y = 0.;
-      pose.theta = 0.;
+          "pose not specified. Set either map_start_pose or map_start_at_dock.");
+      return false;
     }
 
     return true;


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #319  |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | custom |

---

## Description of contribution in a few bullet points

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

* fixed mutually exclusive `map_start_pose` and `map_start_at_dock`
* if none are set use origin and log an error message
