### PR TITLE
Fix deprecated rclcpp::Duration() calls

### DIFF
--- a/include/slam_toolbox/visualization_utils.hpp
+++ b/include/slam_toolbox/visualization_utils.hpp
@@ -46,7 +46,7 @@ inline visualization_msgs::msg::Marker toMarker(
   marker.color.b = 0.0;
   marker.color.a = 1.;
   marker.action = visualization_msgs::msg::Marker::ADD;
-  marker.lifetime = rclcpp::Duration(0.);
+  marker.lifetime = rclcpp::Duration::from_nanoseconds(0);
 
   return marker;
 }

--- a/src/slam_toolbox_common.cpp
+++ b/src/slam_toolbox_common.cpp
@@ -19,6 +19,7 @@
 #include <memory>
 #include <vector>
 #include <string>
+#include <chrono>
 #include "slam_toolbox/slam_toolbox_common.hpp"
 #include "slam_toolbox/serialization.hpp"
 
@@ -39,8 +40,8 @@ SlamToolbox::SlamToolbox(rclcpp::NodeOptions options)
   processor_type_(PROCESS),
   first_measurement_(true),
   process_near_pose_(nullptr),
-  transform_timeout_(rclcpp::Duration(0.5 * 1000000000)),
-  minimum_time_interval_(0.)
+  transform_timeout_(rclcpp::Duration::from_nanoseconds(0.5 * 1000000000)),
+  minimum_time_interval_(std::chrono::nanoseconds(0))
 /*****************************************************************************/
 {
   smapper_ = std::make_unique<mapper_utils::SMapper>();
@@ -150,9 +151,9 @@ void SlamToolbox::setParams()
 
   double tmp_val = 0.5;
   tmp_val = this->declare_parameter("transform_timeout", tmp_val);
-  transform_timeout_ = rclcpp::Duration(tmp_val * 1000000000);
+  transform_timeout_ = rclcpp::Duration::from_nanoseconds(tmp_val * 1000000000);
   tmp_val = this->declare_parameter("minimum_time_interval", tmp_val);
-  minimum_time_interval_ = rclcpp::Duration(tmp_val * 1000000000);
+  minimum_time_interval_ = rclcpp::Duration::from_nanoseconds(tmp_val * 1000000000);
 
   bool debug = false;
   debug = this->declare_parameter("debug_logging", debug);


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (add tickets here #1) |
| Primary OS tested on | (Ubuntu) |
| Robotic platform tested on | (gazebo simulation of Clearpath Dingo) |

---

## Description of contribution in a few bullet points

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

* The latest ros2 API on master deprecated the Duration(rcl_duration_value_t nanoseconds) call without using std::chrono::nanoseconds or rclcpp::Duration::from_nanoseconds(): https://github.com/ros2/rclcpp/blob/master/rclcpp/include/rclcpp/duration.hpp#L42 . This commit fixes the deprecated Duration calls.

## Description of documentation updates required from your changes
none
<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

---

## Future work that may be required in bullet points
none
<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

This fix doesn't make sense for the foxy release, but should be included for the next release of ros2. Should the slam_toolbox have a "ros2" branch to incorporate the latest API changes from the ros2 master branch?
