### PR TITLE
fix the issue (#198) that loop closures can rotate the map 180° if the lidar is mounted backwards

### DIFF
--- a/slam_toolbox/lib/karto_sdk/include/karto_sdk/Karto.h
+++ b/slam_toolbox/lib/karto_sdk/include/karto_sdk/Karto.h
@@ -5634,16 +5634,7 @@ namespace karto
      */
     void SetSensorPose(const Pose2& rScanPose)
     {
-      Pose2 deviceOffsetPose2 = GetLaserRangeFinder()->GetOffsetPose();
-      kt_double offsetLength = deviceOffsetPose2.GetPosition().Length();
-      kt_double offsetHeading = deviceOffsetPose2.GetHeading();
-      kt_double angleoffset = atan2(deviceOffsetPose2.GetY(), deviceOffsetPose2.GetX());
-      kt_double correctedHeading = math::NormalizeAngle(rScanPose.GetHeading());
-      Pose2 worldSensorOffset = Pose2(offsetLength * cos(correctedHeading + angleoffset - offsetHeading),
-                                      offsetLength * sin(correctedHeading + angleoffset - offsetHeading),
-                                      offsetHeading);
-
-      m_CorrectedPose = rScanPose - worldSensorOffset;
+      m_CorrectedPose = GetCorrectedAt(rScanPose);
 
       Update();
     }
@@ -5656,6 +5647,25 @@ namespace karto
     inline Pose2 GetSensorAt(const Pose2& rPose) const
     {
       return Transform(rPose).TransformPose(GetLaserRangeFinder()->GetOffsetPose());
+    }
+
+    /**
+     * @brief Computes the pose of the robot if the sensor were at the given pose
+     * @param sPose sensor pose
+     * @return robot pose
+     */
+    inline Pose2 GetCorrectedAt(const Pose2& sPose) const
+    {
+      Pose2 deviceOffsetPose2 = GetLaserRangeFinder()->GetOffsetPose();
+      kt_double offsetLength = deviceOffsetPose2.GetPosition().Length();
+      kt_double offsetHeading = deviceOffsetPose2.GetHeading();
+      kt_double angleoffset = atan2(deviceOffsetPose2.GetY(), deviceOffsetPose2.GetX());
+      kt_double correctedHeading = math::NormalizeAngle(sPose.GetHeading());
+      Pose2 worldSensorOffset = Pose2(offsetLength * cos(correctedHeading + angleoffset - offsetHeading),
+                                      offsetLength * sin(correctedHeading + angleoffset - offsetHeading),
+                                      offsetHeading);
+
+      return sPose - worldSensorOffset;
     }
 
     /**

--- a/slam_toolbox/lib/karto_sdk/include/karto_sdk/Karto.h
+++ b/slam_toolbox/lib/karto_sdk/include/karto_sdk/Karto.h
@@ -5572,6 +5572,17 @@ namespace karto
 
       m_IsDirty = true;
     }
+    
+    /**
+     * Moves the scan by moving the robot pose to the given location and update point readings.
+     * @param rPose new pose of the robot of this scan
+     */
+    inline void SetCorrectedPoseAndUpdate(const Pose2& rPose)
+    {
+      SetCorrectedPose(rPose);
+      
+      Update();
+    }
 
     /**
      * Gets barycenter of point readings

--- a/slam_toolbox/lib/karto_sdk/src/Mapper.cpp
+++ b/slam_toolbox/lib/karto_sdk/src/Mapper.cpp
@@ -1605,7 +1605,11 @@ namespace karto
     // only attach link information if the edge is new
     if (isNewEdge == true)
     {
-      pEdge->SetLabel(new LinkInfo(pFromScan->GetSensorPose(), rMean, rCovariance));
+      auto corrected_pose=pToScan->GetCorrectedPose();
+      pToScan->SetSensorPose(rMean);
+      auto corrected_mean_pose=pToScan->GetCorrectedPose();
+      pToScan->SetCorrectedPose(corrected_pose);
+      pEdge->SetLabel(new LinkInfo(pFromScan->GetCorrectedPose(), corrected_mean_pose, rCovariance));
       if (m_pMapper->m_pScanOptimizer != NULL)
       {
         m_pMapper->m_pScanOptimizer->AddConstraint(pEdge);
@@ -1988,7 +1992,7 @@ namespace karto
         {
           continue;
         }
-        scan->SetSensorPose(iter->second);
+        scan->SetCorrectedPose(iter->second);
       }
 
       pSolver->Clear();

--- a/slam_toolbox/lib/karto_sdk/src/Mapper.cpp
+++ b/slam_toolbox/lib/karto_sdk/src/Mapper.cpp
@@ -1988,7 +1988,7 @@ namespace karto
         {
           continue;
         }
-        scan->SetCorrectedPose(iter->second);
+        scan->SetCorrectedPoseAndUpdate(iter->second);
       }
 
       pSolver->Clear();

--- a/slam_toolbox/lib/karto_sdk/src/Mapper.cpp
+++ b/slam_toolbox/lib/karto_sdk/src/Mapper.cpp
@@ -1605,11 +1605,7 @@ namespace karto
     // only attach link information if the edge is new
     if (isNewEdge == true)
     {
-      Pose2 corrected_pose = pToScan->GetCorrectedPose();
-      pToScan->SetSensorPose(rMean);
-      Pose2 corrected_mean_pose = pToScan->GetCorrectedPose();
-      pToScan->SetCorrectedPose(corrected_pose);
-      pEdge->SetLabel(new LinkInfo(pFromScan->GetCorrectedPose(), corrected_mean_pose, rCovariance));
+      pEdge->SetLabel(new LinkInfo(pFromScan->GetCorrectedPose(), pToScan->GetCorrectedAt(rMean), rCovariance));
       if (m_pMapper->m_pScanOptimizer != NULL)
       {
         m_pMapper->m_pScanOptimizer->AddConstraint(pEdge);

--- a/slam_toolbox/lib/karto_sdk/src/Mapper.cpp
+++ b/slam_toolbox/lib/karto_sdk/src/Mapper.cpp
@@ -1605,9 +1605,9 @@ namespace karto
     // only attach link information if the edge is new
     if (isNewEdge == true)
     {
-      auto corrected_pose=pToScan->GetCorrectedPose();
+      Pose2 corrected_pose = pToScan->GetCorrectedPose();
       pToScan->SetSensorPose(rMean);
-      auto corrected_mean_pose=pToScan->GetCorrectedPose();
+      Pose2 corrected_mean_pose = pToScan->GetCorrectedPose();
       pToScan->SetCorrectedPose(corrected_pose);
       pEdge->SetLabel(new LinkInfo(pFromScan->GetCorrectedPose(), corrected_mean_pose, rCovariance));
       if (m_pMapper->m_pScanOptimizer != NULL)


### PR DESCRIPTION

Set the edges (constraints) based on the robot base frame (base_footprint) instead of sensor frame (laser).

<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (#198 ) |
| Primary OS tested on | (Ubuntu 20.04 ROS Noetic and Ubuntu 18.04 ROS Melodic) |
| Robotic platform tested on | ([Handsfree mini](https://github.com/HANDS-FREE/handsfree.git) with RPLIDAR A2 mounted backwards) |

---

## Description of contribution in a few bullet points

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->
The reason of weird results of loop closures when lidars are mounted backwards is that the vertices and the edges of the solver are not based on the same frame. The original code sets the pose of the base link (base_footprint) as the vertex pose, but the edges are constraints of 2 poses of sensor frame (laser). That's really unreasonable because the tf between base poses and the tf between their corresponding sensor poses are not the same! The differences are significantly big especially when the sensor is at the opposite orientation of the robot base. So this uncommon loop closure will always happen (more or less) unless the sensor frame is at the exact pose of the base. This is regardless of whether the lidar is 360° or whether it's an RPLIDAR.

I made the edges and vertices based on the same frame. I simply set the edges (constraints) based on the robot base frame (base_footprint) instead of sensor frame (laser).
It works well with my backwards mounted RPLIDAR A2.
## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->
I don't have a ROS2 robot yet. Is anyone there be kind to test this modification on a ROS2 robot?