### PR TITLE
fix issue (#333) initial scan not added to localization buffer [foxy]

### DIFF
--- a/lib/karto_sdk/include/karto_sdk/Mapper.h
+++ b/lib/karto_sdk/include/karto_sdk/Mapper.h
@@ -1974,9 +1974,10 @@ public:
   // processors
   kt_bool ProcessAtDock(LocalizedRangeScan * pScan);
   kt_bool ProcessAgainstNode(LocalizedRangeScan * pScan, const int & nodeId);
-  kt_bool ProcessAgainstNodesNearBy(LocalizedRangeScan * pScan);
+  kt_bool ProcessAgainstNodesNearBy(LocalizedRangeScan * pScan, kt_bool localizationMode = false);
   kt_bool ProcessLocalization(LocalizedRangeScan * pScan);
   kt_bool RemoveNodeFromGraph(Vertex<LocalizedRangeScan> *);
+  void AddScanToLocalizationBuffer(LocalizedRangeScan * pScan, Vertex<LocalizedRangeScan> * scan_vertex);
   void ClearLocalizationBuffer();
 
   /**

--- a/lib/karto_sdk/include/karto_sdk/Mapper.h
+++ b/lib/karto_sdk/include/karto_sdk/Mapper.h
@@ -1974,7 +1974,7 @@ public:
   // processors
   kt_bool ProcessAtDock(LocalizedRangeScan * pScan);
   kt_bool ProcessAgainstNode(LocalizedRangeScan * pScan, const int & nodeId);
-  kt_bool ProcessAgainstNodesNearBy(LocalizedRangeScan * pScan, kt_bool localizationMode = false);
+  kt_bool ProcessAgainstNodesNearBy(LocalizedRangeScan * pScan, kt_bool addScanToLocalizationBuffer = false);
   kt_bool ProcessLocalization(LocalizedRangeScan * pScan);
   kt_bool RemoveNodeFromGraph(Vertex<LocalizedRangeScan> *);
   void AddScanToLocalizationBuffer(LocalizedRangeScan * pScan, Vertex<LocalizedRangeScan> * scan_vertex);

--- a/lib/karto_sdk/src/Mapper.cpp
+++ b/lib/karto_sdk/src/Mapper.cpp
@@ -2676,7 +2676,7 @@ kt_bool Mapper::Process(LocalizedRangeScan * pScan)
   return false;
 }
 
-kt_bool Mapper::ProcessAgainstNodesNearBy(LocalizedRangeScan * pScan, kt_bool localizationMode)
+kt_bool Mapper::ProcessAgainstNodesNearBy(LocalizedRangeScan * pScan, kt_bool addScanToLocalizationBuffer)
 {
   if (pScan != NULL) {
     karto::LaserRangeFinder * pLaserRangeFinder = pScan->GetLaserRangeFinder();
@@ -2742,7 +2742,7 @@ kt_bool Mapper::ProcessAgainstNodesNearBy(LocalizedRangeScan * pScan, kt_bool lo
 
     m_pMapperSensorManager->SetLastScan(pScan);
 
-    if (localizationMode){
+    if (addScanToLocalizationBuffer) {
       AddScanToLocalizationBuffer(pScan, scan_vertex);
     }
 
@@ -2829,7 +2829,7 @@ kt_bool Mapper::ProcessLocalization(LocalizedRangeScan * pScan)
   return true;
 }
 
-void Mapper::AddScanToLocalizationBuffer(LocalizedRangeScan *pScan, Vertex <LocalizedRangeScan> *scan_vertex)
+void Mapper::AddScanToLocalizationBuffer(LocalizedRangeScan * pScan, Vertex <LocalizedRangeScan> * scan_vertex)
 {
   // generate the info to store and later decay, outside of dataset
   LocalizationScanVertex lsv;

--- a/lib/karto_sdk/src/Mapper.cpp
+++ b/lib/karto_sdk/src/Mapper.cpp
@@ -2832,6 +2832,11 @@ kt_bool Mapper::ProcessLocalization(LocalizedRangeScan * pScan)
 void Mapper::AddScanToLocalizationBuffer(LocalizedRangeScan *pScan, Vertex <LocalizedRangeScan> *scan_vertex)
 {
   // generate the info to store and later decay, outside of dataset
+  LocalizationScanVertex lsv;
+  lsv.scan = pScan;
+  lsv.vertex = scan_vertex;
+  m_LocalizationScanVertices.push(lsv);
+
   if (m_LocalizationScanVertices.size() > getParamScanBufferSize()) {
     LocalizationScanVertex & oldLSV = m_LocalizationScanVertices.front();
     RemoveNodeFromGraph(oldLSV.vertex);
@@ -2848,11 +2853,6 @@ void Mapper::AddScanToLocalizationBuffer(LocalizedRangeScan *pScan, Vertex <Loca
 
     m_LocalizationScanVertices.pop();
   }
-
-  LocalizationScanVertex lsv;
-  lsv.scan = pScan;
-  lsv.vertex = scan_vertex;
-  m_LocalizationScanVertices.push(lsv);
 }
 
 void Mapper::ClearLocalizationBuffer()

--- a/lib/karto_sdk/src/Mapper.cpp
+++ b/lib/karto_sdk/src/Mapper.cpp
@@ -2676,7 +2676,7 @@ kt_bool Mapper::Process(LocalizedRangeScan * pScan)
   return false;
 }
 
-kt_bool Mapper::ProcessAgainstNodesNearBy(LocalizedRangeScan * pScan)
+kt_bool Mapper::ProcessAgainstNodesNearBy(LocalizedRangeScan * pScan, kt_bool localizationMode)
 {
   if (pScan != NULL) {
     karto::LaserRangeFinder * pLaserRangeFinder = pScan->GetLaserRangeFinder();
@@ -2722,9 +2722,10 @@ kt_bool Mapper::ProcessAgainstNodesNearBy(LocalizedRangeScan * pScan)
     // add scan to buffer and assign id
     m_pMapperSensorManager->AddScan(pScan);
 
+    Vertex<LocalizedRangeScan> * scan_vertex = NULL;
     if (m_pUseScanMatching->GetValue()) {
       // add to graph
-      m_pGraph->AddVertex(pScan);
+      scan_vertex = m_pGraph->AddVertex(pScan);
       m_pGraph->AddEdges(pScan, covariance);
 
       m_pMapperSensorManager->AddRunningScan(pScan);
@@ -2740,6 +2741,10 @@ kt_bool Mapper::ProcessAgainstNodesNearBy(LocalizedRangeScan * pScan)
     }
 
     m_pMapperSensorManager->SetLastScan(pScan);
+
+    if (localizationMode){
+      AddScanToLocalizationBuffer(pScan, scan_vertex);
+    }
 
     return true;
   }
@@ -2819,7 +2824,13 @@ kt_bool Mapper::ProcessLocalization(LocalizedRangeScan * pScan)
   }
 
   m_pMapperSensorManager->SetLastScan(pScan);
+  AddScanToLocalizationBuffer(pScan, scan_vertex);
 
+  return true;
+}
+
+void Mapper::AddScanToLocalizationBuffer(LocalizedRangeScan *pScan, Vertex <LocalizedRangeScan> *scan_vertex)
+{
   // generate the info to store and later decay, outside of dataset
   if (m_LocalizationScanVertices.size() > getParamScanBufferSize()) {
     LocalizationScanVertex & oldLSV = m_LocalizationScanVertices.front();
@@ -2842,8 +2853,6 @@ kt_bool Mapper::ProcessLocalization(LocalizedRangeScan * pScan)
   lsv.scan = pScan;
   lsv.vertex = scan_vertex;
   m_LocalizationScanVertices.push(lsv);
-
-  return true;
 }
 
 void Mapper::ClearLocalizationBuffer()

--- a/src/slam_toolbox_localization.cpp
+++ b/src/slam_toolbox_localization.cpp
@@ -169,7 +169,7 @@ LocalizedRangeScan * LocalizationSlamToolbox::addScan(
     range_scan->SetOdometricPose(*process_near_pose_);
     range_scan->SetCorrectedPose(range_scan->GetOdometricPose());
     process_near_pose_.reset(nullptr);
-    processed = smapper_->getMapper()->ProcessAgainstNodesNearBy(range_scan);
+    processed = smapper_->getMapper()->ProcessAgainstNodesNearBy(range_scan, true);
 
     // reset to localization mode
     update_reprocessing_transform = true;


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #333 |
| Primary OS tested on | Ubuntu 20.04 |
| Robotic platform tested on | Gazebo simulation |

---

## Description of contribution in a few bullet points
- added parameter to `Mapper::ProcessAgainstNodesNearBy()` to selectively add scan to localization buffer if in localization mode, otherwise (SLAM mode) do as before.
- extracted method for adding new scan to localization buffer
- fixed off-by-one error of localization buffer size


## Description of documentation updates required from your changes

No documentation updates required

---

## Future work that may be required in bullet points

This patch is also required for previous ROS2 version.