### PR TITLE
Support for full 'hit' occupancy grid map [Noetic devel]

### DIFF
--- a/slam_toolbox/include/slam_toolbox/visualization_utils.hpp
+++ b/slam_toolbox/include/slam_toolbox/visualization_utils.hpp
@@ -119,20 +119,16 @@ inline void toNavMap(
     for (kt_int32s x = 0; x < width; x++) 
     {
       kt_int8u value = occ_grid->GetValue(karto::Vector2<kt_int32s>(x, y));
-      switch (value)
-      {
-        case karto::GridStates_Unknown:
-          map.data[MAP_IDX(map.info.width, x, y)] = -1;
-          break;
-        case karto::GridStates_Occupied:
-          map.data[MAP_IDX(map.info.width, x, y)] = 100;
-          break;
-        case karto::GridStates_Free:
-          map.data[MAP_IDX(map.info.width, x, y)] = 0;
-          break;
-        default:
-          ROS_WARN("Encountered unknown cell value at %d, %d", x, y);
-          break;
+      
+      if (value==0){
+        map.data[MAP_IDX(map.info.width, x, y)] = -1;
+      }
+      else if (value>=100 && value<=200){
+        // Scale to 0-100
+        map.data[MAP_IDX(map.info.width, x, y)] = -value + 200;
+      }
+      else{
+        ROS_WARN("Encountered unknown cell value at %d, %d", x, y);
       }
     }
   }

--- a/slam_toolbox/lib/karto_sdk/include/karto_sdk/Karto.h
+++ b/slam_toolbox/lib/karto_sdk/include/karto_sdk/Karto.h
@@ -4443,7 +4443,7 @@ namespace karto
   {
     GridStates_Unknown = 0,
     GridStates_Occupied = 100,
-    GridStates_Free = 255
+    GridStates_Free = 200
   } GridStates;
 
   ////////////////////////////////////////////////////////////////////////////////////////
@@ -6008,7 +6008,7 @@ namespace karto
         throw Exception("Resolution cannot be 0");
       }
 
-      m_pMinPassThrough = new Parameter<kt_int32u>("MinPassThrough", 2);
+      m_pMinPassThrough = new Parameter<kt_int32u>("MinPassThrough", 5);
       m_pOccupancyThreshold = new Parameter<kt_double>("OccupancyThreshold", 0.1);
 
       GetCoordinateConverter()->SetScale(1.0 / resolution);
@@ -6322,7 +6322,7 @@ namespace karto
 
           // increment cell pass through and hit count
           pCellPassCntPtr[index]++;
-          pCellHitCntPtr[index]++;
+          //pCellHitCntPtr[index]++;
 
           if (doUpdate)
           {
@@ -6345,15 +6345,10 @@ namespace karto
       if (cellPassCnt > m_pMinPassThrough->GetValue())
       {
         kt_double hitRatio = static_cast<kt_double>(cellHitCnt) / static_cast<kt_double>(cellPassCnt);
-
-        if (hitRatio > m_pOccupancyThreshold->GetValue())
-        {
-          *pCell = GridStates_Occupied;
-        }
-        else
-        {
-          *pCell = GridStates_Free;
-        }
+	
+	// hitRatio scaled between 100 and 200
+	hitRatio= (-100 * hitRatio + 200);
+	*pCell = (kt_int8u) hitRatio;
       }
     }
 

--- a/slam_toolbox/lib/karto_sdk/include/karto_sdk/Karto.h
+++ b/slam_toolbox/lib/karto_sdk/include/karto_sdk/Karto.h
@@ -6320,9 +6320,8 @@ namespace karto
           kt_int32u* pCellPassCntPtr = m_pCellPassCnt->GetDataPointer();
           kt_int32u* pCellHitCntPtr = m_pCellHitsCnt->GetDataPointer();
 
-          // increment cell pass through and hit count
-          pCellPassCntPtr[index]++;
-          //pCellHitCntPtr[index]++;
+          // increment cell hit count
+          pCellHitCntPtr[index]++;
 
           if (doUpdate)
           {


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | enhancement  |
| Primary OS tested on | Ubuntu 20.04.2 LTS |
| Robotic platform tested on | Several rosbags (i.e. [Magazino](https://google-cartographer-ros.readthedocs.io/en/latest/data.html#magazino) )  |

---

## Description of contribution in a few bullet points

* Each cell from the output map coming from Karto now has a value between 0 and 100 (and -1) in function of its hitRatio value. Previously the cell was directly set to either 0, 100 or -1. 
* Now the map_saver can be used with the --occ and --free arguments to better decide the thresholds of cells occupancy. Previously the hitRatio threshold was rigidly set to  0.1, which is now equivalent to --occ 20 and --free 19.

<p align="center">
<img src="https://user-images.githubusercontent.com/58737870/109781728-746fd200-7c08-11eb-8aaa-7c8ce003ec62.png" width="250">
</p>

## Description of documentation updates required from your changes

* No documentation updates in my opinion

---

## Future work that may be required in bullet points

* Clean the unused variables and comments
* Add it to the ROS2 branch
* Add support to the --occ and --free arguments in the /save_map service 
