### PR TITLE
fix issue (#333) initial scan not added to localization buffer [dashing] 

### DIFF
--- a/lib/karto_sdk/include/karto_sdk/Mapper.h
+++ b/lib/karto_sdk/include/karto_sdk/Mapper.h
@@ -1962,7 +1962,7 @@ namespace karto
     // processors
     kt_bool ProcessAtDock(LocalizedRangeScan* pScan);
     kt_bool ProcessAgainstNode(LocalizedRangeScan* pScan,  const int& nodeId);
-    kt_bool ProcessAgainstNodesNearBy(LocalizedRangeScan* pScan, kt_bool localizationMode = false);
+    kt_bool ProcessAgainstNodesNearBy(LocalizedRangeScan* pScan, kt_bool addScanToLocalizationBuffer = false);
     kt_bool ProcessLocalization(LocalizedRangeScan* pScan);
     kt_bool RemoveNodeFromGraph(Vertex<LocalizedRangeScan>*);
     void AddScanToLocalizationBuffer(LocalizedRangeScan * pScan, Vertex<LocalizedRangeScan> * scan_vertex);

--- a/lib/karto_sdk/include/karto_sdk/Mapper.h
+++ b/lib/karto_sdk/include/karto_sdk/Mapper.h
@@ -609,7 +609,7 @@ namespace karto
       }
       else
       {
-        std::cout << "RemoveVertex: Failed to remove vertex " << idx 
+        std::cout << "RemoveVertex: Failed to remove vertex " << idx
           << " because it doesnt exist in m_Vertices." << std::endl;
       }
     }
@@ -825,7 +825,7 @@ namespace karto
       }
       else
       {
-        std::cout << "GetVertex: Failed to get vertex, idx " << pScan->GetStateId() << 
+        std::cout << "GetVertex: Failed to get vertex, idx " << pScan->GetStateId() <<
           " is not in m_Vertices." << std::endl;
         return nullptr;
       }
@@ -1613,7 +1613,7 @@ namespace karto
       }
       else
       {
-        std::cout << "GetScan: id " << id << 
+        std::cout << "GetScan: id " << id <<
           " does not exist in m_scans, cannot retrieve it." << std::endl;
         return nullptr;
       }
@@ -1962,9 +1962,10 @@ namespace karto
     // processors
     kt_bool ProcessAtDock(LocalizedRangeScan* pScan);
     kt_bool ProcessAgainstNode(LocalizedRangeScan* pScan,  const int& nodeId);
-    kt_bool ProcessAgainstNodesNearBy(LocalizedRangeScan* pScan);
+    kt_bool ProcessAgainstNodesNearBy(LocalizedRangeScan* pScan, kt_bool localizationMode = false);
     kt_bool ProcessLocalization(LocalizedRangeScan* pScan);
     kt_bool RemoveNodeFromGraph(Vertex<LocalizedRangeScan>*);
+    void AddScanToLocalizationBuffer(LocalizedRangeScan * pScan, Vertex<LocalizedRangeScan> * scan_vertex);
     void ClearLocalizationBuffer();
     /**
      * Returns all processed scans added to the mapper.

--- a/lib/karto_sdk/src/Mapper.cpp
+++ b/lib/karto_sdk/src/Mapper.cpp
@@ -2723,7 +2723,7 @@ namespace karto
 	  return false;
   }
 
-  kt_bool Mapper::ProcessAgainstNodesNearBy(LocalizedRangeScan* pScan, kt_bool localizationMode)
+  kt_bool Mapper::ProcessAgainstNodesNearBy(LocalizedRangeScan* pScan, kt_bool addScanToLocalizationBuffer)
   {
     if (pScan != NULL)
     {
@@ -2777,7 +2777,7 @@ namespace karto
       if (m_pUseScanMatching->GetValue())
       {
         // add to graph
-        scan_vertex =m_pGraph->AddVertex(pScan);
+        scan_vertex = m_pGraph->AddVertex(pScan);
         m_pGraph->AddEdges(pScan, covariance);
 
         m_pMapperSensorManager->AddRunningScan(pScan);
@@ -2795,8 +2795,9 @@ namespace karto
 
       m_pMapperSensorManager->SetLastScan(pScan);
 
-      if (localizationMode){
-      AddScanToLocalizationBuffer(pScan, scan_vertex);
+      if (addScanToLocalizationBuffer)
+      {
+        AddScanToLocalizationBuffer(pScan, scan_vertex);
       }
 
       return true;
@@ -2889,7 +2890,7 @@ namespace karto
     return true;
   }
 
-  void Mapper::AddScanToLocalizationBuffer(LocalizedRangeScan *pScan, Vertex <LocalizedRangeScan> *scan_vertex)
+  void Mapper::AddScanToLocalizationBuffer(LocalizedRangeScan * pScan, Vertex <LocalizedRangeScan> * scan_vertex)
   {
     // generate the info to store and later decay, outside of dataset
     LocalizationScanVertex lsv;

--- a/lib/karto_sdk/src/Mapper.cpp
+++ b/lib/karto_sdk/src/Mapper.cpp
@@ -177,7 +177,7 @@ namespace karto
         squaredDistance = frontScanPose.GetPosition().SquaredDistance(backScanPose.GetPosition());
       }
     }
-    
+
     /**
      * Finds and replaces a scan from m_scans with NULL
      * @param pScan
@@ -230,7 +230,7 @@ namespace karto
     LocalizedRangeScanMap m_Scans;
     LocalizedRangeScanVector m_RunningScans;
     LocalizedRangeScan* m_pLastScan;
-    kt_int32u m_NextStateId;    
+    kt_int32u m_NextStateId;
 
     kt_int32u m_RunningBufferMaximumSize;
     kt_double m_RunningBufferMaximumDistance;
@@ -341,7 +341,7 @@ namespace karto
   void MapperSensorManager::RemoveScan(LocalizedRangeScan* pScan)
   {
     GetScanManager(pScan)->RemoveScan(pScan);
-    
+
     LocalizedRangeScanMap::iterator it = m_Scans.find(pScan->GetStateId());
     if (it != m_Scans.end())
     {
@@ -2723,7 +2723,7 @@ namespace karto
 	  return false;
   }
 
-  kt_bool Mapper::ProcessAgainstNodesNearBy(LocalizedRangeScan* pScan)
+  kt_bool Mapper::ProcessAgainstNodesNearBy(LocalizedRangeScan* pScan, kt_bool localizationMode)
   {
     if (pScan != NULL)
     {
@@ -2773,10 +2773,11 @@ namespace karto
       // add scan to buffer and assign id
       m_pMapperSensorManager->AddScan(pScan);
 
+      Vertex<LocalizedRangeScan> * scan_vertex = NULL;
       if (m_pUseScanMatching->GetValue())
       {
         // add to graph
-        m_pGraph->AddVertex(pScan);
+        scan_vertex =m_pGraph->AddVertex(pScan);
         m_pGraph->AddEdges(pScan, covariance);
 
         m_pMapperSensorManager->AddRunningScan(pScan);
@@ -2793,6 +2794,10 @@ namespace karto
       }
 
       m_pMapperSensorManager->SetLastScan(pScan);
+
+      if (localizationMode){
+      AddScanToLocalizationBuffer(pScan, scan_vertex);
+      }
 
       return true;
     }
@@ -2835,7 +2840,7 @@ namespace karto
         pScan->GetOdometricPose()));
     }
 
-    // test if scan is outside minimum boundary 
+    // test if scan is outside minimum boundary
     // or if heading is larger then minimum heading
     if (!HasMovedEnough(pScan, pLastScan))
     {
@@ -2867,7 +2872,7 @@ namespace karto
       m_pGraph->AddEdges(pScan, covariance);
 
       m_pMapperSensorManager->AddRunningScan(pScan);
-      
+
       if (m_pDoLoopClosing->GetValue())
       {
         std::vector<Name> deviceNames = m_pMapperSensorManager->GetSensorNames();
@@ -2879,7 +2884,13 @@ namespace karto
     }
 
     m_pMapperSensorManager->SetLastScan(pScan);
+    AddScanToLocalizationBuffer(pScan, scan_vertex);
 
+    return true;
+  }
+
+  void Mapper::AddScanToLocalizationBuffer(LocalizedRangeScan *pScan, Vertex <LocalizedRangeScan> *scan_vertex)
+  {
     // generate the info to store and later decay, outside of dataset
     if (m_LocalizationScanVertices.size() > getParamScanBufferSize())
     {
@@ -2904,8 +2915,6 @@ namespace karto
     lsv.scan = pScan;
     lsv.vertex = scan_vertex;
     m_LocalizationScanVertices.push(lsv);
-
-    return true;
   }
 
   void Mapper::ClearLocalizationBuffer()
@@ -2952,7 +2961,7 @@ namespace karto
           adjVerts[i]->RemoveEdge(j);
           m_pScanOptimizer->RemoveConstraint(
             adjEdges[j]->GetSource()->GetObject()->GetUniqueId(),
-            adjEdges[j]->GetTarget()->GetObject()->GetUniqueId()); 
+            adjEdges[j]->GetTarget()->GetObject()->GetUniqueId());
           std::vector<Edge<LocalizedRangeScan>*> edges = m_pGraph->GetEdges();
           std::vector<Edge<LocalizedRangeScan>*>::iterator edgeGraphIt =
             std::find(edges.begin(), edges.end(), adjEdges[j]);
@@ -2981,7 +2990,7 @@ namespace karto
     m_pScanOptimizer->RemoveNode(vertex_to_remove->GetObject()->GetUniqueId());
 
     // 3) delete from vertex map
-    std::map<Name, std::map<int, Vertex<LocalizedRangeScan>*> > 
+    std::map<Name, std::map<int, Vertex<LocalizedRangeScan>*> >
       vertexMap = m_pGraph->GetVertices();
     std::map<int, Vertex<LocalizedRangeScan>*> graphVertices =
       vertexMap[vertex_to_remove->GetObject()->GetSensorName()];
@@ -3001,7 +3010,7 @@ namespace karto
     return true;
   }
 
-  kt_bool Mapper::ProcessAgainstNode(LocalizedRangeScan* pScan, 
+  kt_bool Mapper::ProcessAgainstNode(LocalizedRangeScan* pScan,
     const int& nodeId)
   {
     if (pScan != NULL)
@@ -3009,7 +3018,7 @@ namespace karto
       karto::LaserRangeFinder* pLaserRangeFinder = pScan->GetLaserRangeFinder();
 
       // validate scan
-      if (pLaserRangeFinder == NULL || pScan == NULL || 
+      if (pLaserRangeFinder == NULL || pScan == NULL ||
         pLaserRangeFinder->Validate(pScan) == false)
       {
         return false;

--- a/lib/karto_sdk/src/Mapper.cpp
+++ b/lib/karto_sdk/src/Mapper.cpp
@@ -2892,6 +2892,11 @@ namespace karto
   void Mapper::AddScanToLocalizationBuffer(LocalizedRangeScan *pScan, Vertex <LocalizedRangeScan> *scan_vertex)
   {
     // generate the info to store and later decay, outside of dataset
+    LocalizationScanVertex lsv;
+    lsv.scan = pScan;
+    lsv.vertex = scan_vertex;
+    m_LocalizationScanVertices.push(lsv);
+
     if (m_LocalizationScanVertices.size() > getParamScanBufferSize())
     {
       LocalizationScanVertex& oldLSV = m_LocalizationScanVertices.front();
@@ -2911,10 +2916,7 @@ namespace karto
       m_LocalizationScanVertices.pop();
     }
 
-    LocalizationScanVertex lsv;
-    lsv.scan = pScan;
-    lsv.vertex = scan_vertex;
-    m_LocalizationScanVertices.push(lsv);
+
   }
 
   void Mapper::ClearLocalizationBuffer()

--- a/src/slam_toolbox_localization.cpp
+++ b/src/slam_toolbox_localization.cpp
@@ -179,7 +179,7 @@ LocalizedRangeScan* LocalizationSlamToolbox::addScan(
     range_scan->SetOdometricPose(*process_near_pose_);
     range_scan->SetCorrectedPose(range_scan->GetOdometricPose());
     process_near_pose_.reset(nullptr);
-    processed = smapper_->getMapper()->ProcessAgainstNodesNearBy(range_scan);
+    processed = smapper_->getMapper()->ProcessAgainstNodesNearBy(range_scan, true);
 
     // reset to localization mode
     update_reprocessing_transform = true;


### PR DESCRIPTION
#343 for `dashing-devel` branch

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #333 |
| Primary OS tested on | Ubuntu 20.04 |
| Robotic platform tested on | Gazebo simulation (foxy)|

---

## Description of contribution in a few bullet points
- added parameter to `Mapper::ProcessAgainstNodesNearBy()` to selectively add scan to localization buffer if in localization mode, otherwise (SLAM mode) do as before.
- extracted method for adding new scan to localization buffer
- fixed off-by-one error of localization buffer size


## Description of documentation updates required from your changes

No documentation updates required

---

## Future work that may be required in bullet points
