### PR TITLE
  fix issue (#333) initial scan not added to localization buffer [noetic]

### DIFF
--- a/slam_toolbox/lib/karto_sdk/include/karto_sdk/Mapper.h
+++ b/slam_toolbox/lib/karto_sdk/include/karto_sdk/Mapper.h
@@ -1960,9 +1960,10 @@ namespace karto
     // processors
     kt_bool ProcessAtDock(LocalizedRangeScan* pScan);
     kt_bool ProcessAgainstNode(LocalizedRangeScan* pScan,  const int& nodeId);
-    kt_bool ProcessAgainstNodesNearBy(LocalizedRangeScan* pScan);
+    kt_bool ProcessAgainstNodesNearBy(LocalizedRangeScan* pScan, kt_bool addScanToLocalizationBuffer = false);
     kt_bool ProcessLocalization(LocalizedRangeScan* pScan);
     kt_bool RemoveNodeFromGraph(Vertex<LocalizedRangeScan>*);
+    void AddScanToLocalizationBuffer(LocalizedRangeScan* pScan, Vertex<LocalizedRangeScan>* scan_vertex);
     void ClearLocalizationBuffer();
 
     /**

--- a/slam_toolbox/lib/karto_sdk/src/Mapper.cpp
+++ b/slam_toolbox/lib/karto_sdk/src/Mapper.cpp
@@ -2897,6 +2897,11 @@ namespace karto
   {
 
     // generate the info to store and later decay, outside of dataset
+    LocalizationScanVertex lsv;
+    lsv.scan = pScan;
+    lsv.vertex = scan_vertex;
+    m_LocalizationScanVertices.push(lsv);
+
     if (m_LocalizationScanVertices.size() > getParamScanBufferSize())
     {
       LocalizationScanVertex& oldLSV = m_LocalizationScanVertices.front();
@@ -2915,11 +2920,6 @@ namespace karto
 
       m_LocalizationScanVertices.pop();
     }
-
-    LocalizationScanVertex lsv;
-    lsv.scan = pScan;
-    lsv.vertex = scan_vertex;
-    m_LocalizationScanVertices.push(lsv);
   }
 
   void Mapper::ClearLocalizationBuffer()

--- a/slam_toolbox/lib/karto_sdk/src/Mapper.cpp
+++ b/slam_toolbox/lib/karto_sdk/src/Mapper.cpp
@@ -2725,7 +2725,7 @@ namespace karto
 	  return false;
   }
 
-  kt_bool Mapper::ProcessAgainstNodesNearBy(LocalizedRangeScan* pScan)
+  kt_bool Mapper::ProcessAgainstNodesNearBy(LocalizedRangeScan* pScan, kt_bool addScanToLocalizationBuffer)
   {
     if (pScan != NULL)
     {
@@ -2775,8 +2775,10 @@ namespace karto
       // add scan to buffer and assign id
       m_pMapperSensorManager->AddScan(pScan);
 
+      Vertex<LocalizedRangeScan>* scan_vertex = NULL;
       if (m_pUseScanMatching->GetValue())
       {
+        scan_vertex = m_pGraph->AddVertex(pScan);
         // add to graph
         m_pGraph->AddVertex(pScan);
         m_pGraph->AddEdges(pScan, covariance);
@@ -2795,6 +2797,11 @@ namespace karto
       }
 
       m_pMapperSensorManager->SetLastScan(pScan);
+
+      if (addScanToLocalizationBuffer)
+      {
+        AddScanToLocalizationBuffer(pScan, scan_vertex);
+      }
 
       return true;
     }
@@ -2881,6 +2888,13 @@ namespace karto
     }
 
     m_pMapperSensorManager->SetLastScan(pScan);
+    AddScanToLocalizationBuffer(pScan, scan_vertex);
+
+    return true;
+  }
+
+  void Mapper::AddScanToLocalizationBuffer(LocalizedRangeScan * pScan, Vertex <LocalizedRangeScan> * scan_vertex)
+  {
 
     // generate the info to store and later decay, outside of dataset
     if (m_LocalizationScanVertices.size() > getParamScanBufferSize())
@@ -2906,8 +2920,6 @@ namespace karto
     lsv.scan = pScan;
     lsv.vertex = scan_vertex;
     m_LocalizationScanVertices.push(lsv);
-
-    return true;
   }
 
   void Mapper::ClearLocalizationBuffer()

--- a/slam_toolbox/src/slam_toolbox_localization.cpp
+++ b/slam_toolbox/src/slam_toolbox_localization.cpp
@@ -161,7 +161,7 @@ LocalizedRangeScan* LocalizationSlamToolbox::addScan(
     range_scan->SetOdometricPose(*process_near_pose_);
     range_scan->SetCorrectedPose(range_scan->GetOdometricPose());
     process_near_pose_.reset(nullptr);
-    processed = smapper_->getMapper()->ProcessAgainstNodesNearBy(range_scan);
+    processed = smapper_->getMapper()->ProcessAgainstNodesNearBy(range_scan, true);
 
     // reset to localization mode
     processor_type_ = PROCESS_LOCALIZATION;


### PR DESCRIPTION
#343 for `noetic-devel` branch

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #333 |
| Primary OS tested on | Ubuntu 20.04 |
| Robotic platform tested on | Gazebo simulation (foxy)|

---

## Description of contribution in a few bullet points
- added parameter to `Mapper::ProcessAgainstNodesNearBy()` to selectively add scan to localization buffer if in localization mode, otherwise (SLAM mode) do as before.
- extracted method for adding new scan to localization buffer
- fixed off-by-one error of localization buffer size


## Description of documentation updates required from your changes

No documentation updates required

---

## Future work that may be required in bullet points
