### PR TITLE
Revert "Rename params_file to slam_params_file to avoid name conflicts" [foxy]

### DIFF
--- a/launch/online_async_launch.py
+++ b/launch/online_async_launch.py
@@ -9,21 +9,21 @@ from ament_index_python.packages import get_package_share_directory
 
 def generate_launch_description():
     use_sim_time = LaunchConfiguration('use_sim_time')
-    slam_params_file = LaunchConfiguration('slam_params_file')
+    params_file = LaunchConfiguration('params_file')
 
     declare_use_sim_time_argument = DeclareLaunchArgument(
         'use_sim_time',
         default_value='true',
         description='Use simulation/Gazebo clock')
-    declare_slam_params_file_cmd = DeclareLaunchArgument(
-        'slam_params_file',
+    declare_params_file_cmd = DeclareLaunchArgument(
+        'params_file',
         default_value=os.path.join(get_package_share_directory("slam_toolbox"),
                                    'config', 'mapper_params_online_async.yaml'),
         description='Full path to the ROS2 parameters file to use for the slam_toolbox node')
 
     start_async_slam_toolbox_node = Node(
         parameters=[
-          slam_params_file,
+          params_file,
           {'use_sim_time': use_sim_time}
         ],
         package='slam_toolbox',
@@ -34,7 +34,7 @@ def generate_launch_description():
     ld = LaunchDescription()
 
     ld.add_action(declare_use_sim_time_argument)
-    ld.add_action(declare_slam_params_file_cmd)
+    ld.add_action(declare_params_file_cmd)
     ld.add_action(start_async_slam_toolbox_node)
 
     return ld

--- a/launch/online_sync_launch.py
+++ b/launch/online_sync_launch.py
@@ -9,21 +9,21 @@ from ament_index_python.packages import get_package_share_directory
 
 def generate_launch_description():
     use_sim_time = LaunchConfiguration('use_sim_time')
-    slam_params_file = LaunchConfiguration('slam_params_file')
+    params_file = LaunchConfiguration('params_file')
 
     declare_use_sim_time_argument = DeclareLaunchArgument(
         'use_sim_time',
         default_value='true',
         description='Use simulation/Gazebo clock')
-    declare_slam_params_file_cmd = DeclareLaunchArgument(
-        'slam_params_file',
+    declare_params_file_cmd = DeclareLaunchArgument(
+        'params_file',
         default_value=os.path.join(get_package_share_directory("slam_toolbox"),
                                    'config', 'mapper_params_online_sync.yaml'),
         description='Full path to the ROS2 parameters file to use for the slam_toolbox node')
 
     start_sync_slam_toolbox_node = Node(
         parameters=[
-          slam_params_file,
+          params_file,
           {'use_sim_time': use_sim_time}
         ],
         package='slam_toolbox',
@@ -34,7 +34,7 @@ def generate_launch_description():
     ld = LaunchDescription()
 
     ld.add_action(declare_use_sim_time_argument)
-    ld.add_action(declare_slam_params_file_cmd)
+    ld.add_action(declare_params_file_cmd)
     ld.add_action(start_sync_slam_toolbox_node)
 
     return ld


### PR DESCRIPTION
Reverts SteveMacenski/slam_toolbox#364 due to renaming parameter in launch file some may rely on