### PR TITLE
Fixed error for function MapperSensorManager::RemoveScan [foxy]

### DIFF
--- a/lib/karto_sdk/src/Mapper.cpp
+++ b/lib/karto_sdk/src/Mapper.cpp
@@ -342,7 +342,7 @@ void MapperSensorManager::RemoveScan(LocalizedRangeScan * pScan)
 {
   GetScanManager(pScan)->RemoveScan(pScan);
 
-  LocalizedRangeScanMap::iterator it = m_Scans.find(pScan->GetStateId());
+  LocalizedRangeScanMap::iterator it = m_Scans.find(pScan->GetUniqueId());
   if (it != m_Scans.end()) {
     it->second = NULL;
     m_Scans.erase(it);


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | N\A |
| Primary OS tested on | Ubuntu 18.04 |
| Robotic platform tested on | Gazebo simulation |

---

## Description of contribution in a few bullet points

* m_Scans in class MapperSensorManager is indexed using the **UniqueId** of the scan, as we can easy see when looking to MapperSensorManager::AddScan, for example
* But, in MapperSensorManager::RemoveScan, the scan to remove is searched using the **StateId**, instead
* This is not an issue if only one sensor is used, since StateId and UniqueId are the same, but it becomes an issue if more than one sensor is used

## Description of documentation updates required from your changes

* No updates

---

## Future work that may be required in bullet points

* Nothing
