### PR TITLE
fixed timestamps input&output not synchronized 

### DIFF
--- a/include/slam_toolbox/slam_toolbox_common.hpp
+++ b/include/slam_toolbox/slam_toolbox_common.hpp
@@ -138,6 +138,7 @@ protected:
   // Storage for ROS parameters
   std::string odom_frame_, map_frame_, base_frame_, map_name_, scan_topic_;
   rclcpp::Duration transform_timeout_, minimum_time_interval_;
+  rclcpp::Time scan_timestamped;
   int throttle_scans_;
 
   double resolution_;

--- a/include/slam_toolbox/visualization_utils.hpp
+++ b/include/slam_toolbox/visualization_utils.hpp
@@ -50,7 +50,7 @@ inline visualization_msgs::msg::Marker toMarker(
   marker.color.b = 0.0;
   marker.color.a = 1.;
   marker.action = visualization_msgs::msg::Marker::ADD;
-  marker.lifetime = rclcpp::Duration(0.);
+  marker.lifetime = rclcpp::Duration::from_nanoseconds(0);
 
   return marker;
 }

--- a/include/slam_toolbox/visualization_utils.hpp
+++ b/include/slam_toolbox/visualization_utils.hpp
@@ -50,7 +50,7 @@ inline visualization_msgs::msg::Marker toMarker(
   marker.color.b = 0.0;
   marker.color.a = 1.;
   marker.action = visualization_msgs::msg::Marker::ADD;
-  marker.lifetime = rclcpp::Duration::from_nanoseconds(0);
+  marker.lifetime = rclcpp::Duration(0.);
 
   return marker;
 }

--- a/src/experimental/slam_toolbox_lifelong.cpp
+++ b/src/experimental/slam_toolbox_lifelong.cpp
@@ -85,7 +85,6 @@ void LifelongSlamToolbox::laserCallback(
 {
   // store scan timestamped
   scan_timestamped = scan->header.stamp;
-
   // no odom info
   Pose2 pose;
   if (!pose_helper_->getOdomPose(pose, scan->header.stamp)) {

--- a/src/experimental/slam_toolbox_lifelong.cpp
+++ b/src/experimental/slam_toolbox_lifelong.cpp
@@ -83,6 +83,9 @@ void LifelongSlamToolbox::laserCallback(
   sensor_msgs::msg::LaserScan::ConstSharedPtr scan)
 /*****************************************************************************/
 {
+  // store scan timestamped
+  scan_timestamped = scan->header.stamp;
+
   // no odom info
   Pose2 pose;
   if (!pose_helper_->getOdomPose(pose, scan->header.stamp)) {

--- a/src/slam_toolbox_async.cpp
+++ b/src/slam_toolbox_async.cpp
@@ -37,7 +37,6 @@ void AsynchronousSlamToolbox::laserCallback(
 {
   // store scan timestamped
   scan_timestamped = scan->header.stamp;
-  
   // no odom info
   Pose2 pose;
   if (!pose_helper_->getOdomPose(pose, scan->header.stamp)) {

--- a/src/slam_toolbox_async.cpp
+++ b/src/slam_toolbox_async.cpp
@@ -35,6 +35,9 @@ void AsynchronousSlamToolbox::laserCallback(
   sensor_msgs::msg::LaserScan::ConstSharedPtr scan)
 /*****************************************************************************/
 {
+  // store scan timestamped
+  scan_timestamped = scan->header.stamp;
+  
   // no odom info
   Pose2 pose;
   if (!pose_helper_->getOdomPose(pose, scan->header.stamp)) {

--- a/src/slam_toolbox_common.cpp
+++ b/src/slam_toolbox_common.cpp
@@ -40,7 +40,7 @@ SlamToolbox::SlamToolbox(rclcpp::NodeOptions options)
   processor_type_(PROCESS),
   first_measurement_(true),
   process_near_pose_(nullptr),
-  transform_timeout_(rclcpp::Duration::from_nanoseconds(0.5 * 1000000000)),
+  transform_timeout_(rclcpp::Duration::from_seconds(0.5 )),
   minimum_time_interval_(std::chrono::nanoseconds(0))
 /*****************************************************************************/
 {
@@ -151,9 +151,9 @@ void SlamToolbox::setParams()
 
   double tmp_val = 0.5;
   tmp_val = this->declare_parameter("transform_timeout", tmp_val);
-  transform_timeout_ = rclcpp::Duration::from_nanoseconds(tmp_val * 1000000000);
+  transform_timeout_ = rclcpp::Duration::from_seconds(tmp_val);
   tmp_val = this->declare_parameter("minimum_time_interval", tmp_val);
-  minimum_time_interval_ = rclcpp::Duration::from_nanoseconds(tmp_val * 1000000000);
+  minimum_time_interval_ = rclcpp::Duration::from_seconds(tmp_val);
 
   bool debug = false;
   debug = this->declare_parameter("debug_logging", debug);
@@ -231,7 +231,7 @@ void SlamToolbox::publishTransformLoop(
       msg.transform = tf2::toMsg(map_to_odom_);
       msg.child_frame_id = odom_frame_;
       msg.header.frame_id = map_frame_;
-      msg.header.stamp = this->now() + transform_timeout_;
+      msg.header.stamp = scan_timestamped + transform_timeout_; // 8 Apr.21 | remove this->now 
       tfB_->sendTransform(msg);
     }
     r.sleep();
@@ -372,7 +372,7 @@ bool SlamToolbox::updateMap()
   vis_utils::toNavMap(occ_grid, map_.map);
 
   // publish map as current
-  map_.map.header.stamp = this->now();
+  map_.map.header.stamp = scan_timestamped;
   sst_->publish(
     std::move(std::make_unique<nav_msgs::msg::OccupancyGrid>(map_.map)));
   sstm_->publish(

--- a/src/slam_toolbox_common.cpp
+++ b/src/slam_toolbox_common.cpp
@@ -231,7 +231,7 @@ void SlamToolbox::publishTransformLoop(
       msg.transform = tf2::toMsg(map_to_odom_);
       msg.child_frame_id = odom_frame_;
       msg.header.frame_id = map_frame_;
-      msg.header.stamp = scan_timestamped + transform_timeout_; // 8 Apr.21 | remove this->now 
+      msg.header.stamp = scan_timestamped + transform_timeout_; 
       tfB_->sendTransform(msg);
     }
     r.sleep();

--- a/src/slam_toolbox_common.cpp
+++ b/src/slam_toolbox_common.cpp
@@ -40,7 +40,7 @@ SlamToolbox::SlamToolbox(rclcpp::NodeOptions options)
   processor_type_(PROCESS),
   first_measurement_(true),
   process_near_pose_(nullptr),
-  transform_timeout_(rclcpp::Duration::from_seconds(0.5 )),
+  transform_timeout_(rclcpp::Duration::from_seconds(0.5)),
   minimum_time_interval_(std::chrono::nanoseconds(0))
 /*****************************************************************************/
 {
@@ -231,7 +231,7 @@ void SlamToolbox::publishTransformLoop(
       msg.transform = tf2::toMsg(map_to_odom_);
       msg.child_frame_id = odom_frame_;
       msg.header.frame_id = map_frame_;
-      msg.header.stamp = scan_timestamped + transform_timeout_; 
+      msg.header.stamp = scan_timestamped + transform_timeout_;
       tfB_->sendTransform(msg);
     }
     r.sleep();

--- a/src/slam_toolbox_localization.cpp
+++ b/src/slam_toolbox_localization.cpp
@@ -117,6 +117,9 @@ void LocalizationSlamToolbox::laserCallback(
   sensor_msgs::msg::LaserScan::ConstSharedPtr scan)
 /*****************************************************************************/
 {
+  // store scan timestamped
+  scan_timestamped = scan->header.stamp;
+
   // no odom info
   Pose2 pose;
   if (!pose_helper_->getOdomPose(pose, scan->header.stamp)) {

--- a/src/slam_toolbox_localization.cpp
+++ b/src/slam_toolbox_localization.cpp
@@ -120,7 +120,6 @@ void LocalizationSlamToolbox::laserCallback(
 {
   // store scan timestamped
   scan_timestamped = scan->header.stamp;
-
   // no odom info
   Pose2 pose;
   if (!pose_helper_->getOdomPose(pose, scan->header.stamp)) {

--- a/src/slam_toolbox_sync.cpp
+++ b/src/slam_toolbox_sync.cpp
@@ -65,6 +65,9 @@ void SynchronousSlamToolbox::laserCallback(
   sensor_msgs::msg::LaserScan::ConstSharedPtr scan)
 /*****************************************************************************/
 {
+  // store scan timestamped
+  scan_timestamped = scan->header.stamp;
+
   // no odom info
   Pose2 pose;
   if (!pose_helper_->getOdomPose(pose, scan->header.stamp)) {

--- a/src/slam_toolbox_sync.cpp
+++ b/src/slam_toolbox_sync.cpp
@@ -67,7 +67,6 @@ void SynchronousSlamToolbox::laserCallback(
 {
   // store scan timestamped
   scan_timestamped = scan->header.stamp;
-
   // no odom info
   Pose2 pose;
   if (!pose_helper_->getOdomPose(pose, scan->header.stamp)) {


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ |------|
| Ticket | #376 
| Test on | Ubuntu 20.04 ROS2 Foxy, rosbag 


---

## Description of contribution in a few bullet points

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->
*  I changed msg.header.stamp in `SlamToolbox::updateMap` and `SlamToolbox::publishTransformLoop` from this->now() to latest `/scan` timestamps (store in ::laserCallback)  
 
## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->
