### PR TITLE
[noetic] change karto library name so that the package is installable...

### DIFF
--- a/slam_toolbox/CMakeLists.txt
+++ b/slam_toolbox/CMakeLists.txt
@@ -95,26 +95,26 @@ target_link_libraries(ceres_solver_plugin ${catkin_LIBRARIES}
 
 #### Tool lib for mapping
 add_library(toolbox_common src/slam_toolbox_common.cpp src/map_saver.cpp src/loop_closure_assistant.cpp src/laser_utils.cpp src/slam_mapper.cpp)
-target_link_libraries(toolbox_common karto ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(toolbox_common kartoSlamToolbox ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 #### Mapping executibles
 add_library(async_slam_toolbox src/slam_toolbox_async.cpp)
-target_link_libraries(async_slam_toolbox toolbox_common karto ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(async_slam_toolbox toolbox_common kartoSlamToolbox ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 add_executable(async_slam_toolbox_node src/slam_toolbox_async_node.cpp )
 target_link_libraries(async_slam_toolbox_node async_slam_toolbox)
 
 add_library(sync_slam_toolbox src/slam_toolbox_sync.cpp)
-target_link_libraries(sync_slam_toolbox toolbox_common karto ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(sync_slam_toolbox toolbox_common kartoSlamToolbox ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 add_executable(sync_slam_toolbox_node src/slam_toolbox_sync_node.cpp )
 target_link_libraries(sync_slam_toolbox_node sync_slam_toolbox)
 
 add_library(localization_slam_toolbox src/slam_toolbox_localization.cpp)
-target_link_libraries(localization_slam_toolbox toolbox_common karto ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(localization_slam_toolbox toolbox_common kartoSlamToolbox ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 add_executable(localization_slam_toolbox_node src/slam_toolbox_localization_node.cpp )
 target_link_libraries(localization_slam_toolbox_node localization_slam_toolbox)
 
 add_library(lifelong_slam_toolbox src/experimental/slam_toolbox_lifelong.cpp)
-target_link_libraries(lifelong_slam_toolbox toolbox_common karto ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(lifelong_slam_toolbox toolbox_common kartoSlamToolbox ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 add_executable(lifelong_slam_toolbox_node src/experimental/slam_toolbox_lifelong_node.cpp )
 target_link_libraries(lifelong_slam_toolbox_node lifelong_slam_toolbox)
 

--- a/slam_toolbox/lib/karto_sdk/CMakeLists.txt
+++ b/slam_toolbox/lib/karto_sdk/CMakeLists.txt
@@ -19,16 +19,16 @@ catkin_package(
     include
     ${TBB_INCLUDE_DIRS}
   LIBRARIES
-    karto
+    kartoSlamToolbox
 )
 
 add_definitions(${EIGEN3_DEFINITIONS})
 
 include_directories(include ${catkin_INCLUDE_DIRS} ${EIGEN3_INCLUDE_DIRS} ${TBB_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
-add_library(karto SHARED src/Karto.cpp src/Mapper.cpp)
-target_link_libraries(karto ${Boost_LIBRARIES} ${TBB_LIBRARIES})
+add_library(kartoSlamToolbox SHARED src/Karto.cpp src/Mapper.cpp)
+target_link_libraries(kartoSlamToolbox ${Boost_LIBRARIES} ${TBB_LIBRARIES})
 
 install(DIRECTORY include/ DESTINATION include)
-install(TARGETS karto
+install(TARGETS kartoSlamToolbox
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
 )


### PR DESCRIPTION
…alongside open_karto

Without this patch, installing slam toolbox results in:
```
dpkg: error processing archive /tmp/apt-dpkg-install-2E6ylt/1797-ros-noetic-slam-toolbox_1.5.4-1focal.20210112.085557_amd64.deb (--unpack):
 trying to overwrite '/opt/ros/noetic/lib/libkarto.so', which is also in package ros-noetic-open-karto 1.2.2-1focal.20201014.202229
dpkg-deb: error: paste subprocess was killed by signal (Broken pipe)

```

Forward port of #173 to noetic-devel
More info at https://github.com/SteveMacenski/slam_toolbox/issues/171