### PR TITLE
fix issue (#180) that localization mode may terminate unexpectedly with exception about pthread_mutex_lock

### DIFF
--- a/slam_toolbox/lib/karto_sdk/CMakeLists.txt
+++ b/slam_toolbox/lib/karto_sdk/CMakeLists.txt
@@ -9,7 +9,7 @@ find_package(catkin REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(Boost REQUIRED system serialization filesystem thread)
 find_package(TBB REQUIRED)
-add_compile_options(-std=c++11)
+add_compile_options(-std=c++17)
 
 catkin_package(
   DEPENDS 

--- a/slam_toolbox/lib/karto_sdk/include/karto_sdk/Karto.h
+++ b/slam_toolbox/lib/karto_sdk/include/karto_sdk/Karto.h
@@ -28,6 +28,7 @@
 #include <iomanip>
 #include <sstream>
 #include <stdexcept>
+#include <shared_mutex>
 
 #include <math.h>
 #include <float.h>
@@ -5528,7 +5529,7 @@ namespace karto
     }
 
   private:
-    mutable boost::shared_mutex m_Lock;
+    mutable std::shared_mutex m_Lock;
 
   public:
     /**
@@ -5589,12 +5590,12 @@ namespace karto
      */
     inline const Pose2& GetBarycenterPose() const
     {
-      boost::shared_lock<boost::shared_mutex> lock(m_Lock);
+      std::shared_lock<std::shared_mutex> lock(m_Lock);
       if (m_IsDirty)
       {
         // throw away constness and do an update!
         lock.unlock();
-        boost::unique_lock<boost::shared_mutex> uniqueLock(m_Lock);
+        std::unique_lock<std::shared_mutex> uniqueLock(m_Lock);
         const_cast<LocalizedRangeScan*>(this)->Update();
       }
 
@@ -5613,12 +5614,12 @@ namespace karto
      */
     inline Pose2 GetReferencePose(kt_bool useBarycenter) const
     {
-      boost::shared_lock<boost::shared_mutex> lock(m_Lock);
+      std::shared_lock<std::shared_mutex> lock(m_Lock);
       if (m_IsDirty)
       {
         // throw away constness and do an update!
         lock.unlock();
-        boost::unique_lock<boost::shared_mutex> uniqueLock(m_Lock);
+        std::unique_lock<std::shared_mutex> uniqueLock(m_Lock);
         const_cast<LocalizedRangeScan*>(this)->Update();
       }
 
@@ -5685,12 +5686,12 @@ namespace karto
      */
     inline const BoundingBox2& GetBoundingBox() const
     {
-      boost::shared_lock<boost::shared_mutex> lock(m_Lock);
+      std::shared_lock<std::shared_mutex> lock(m_Lock);
       if (m_IsDirty)
       {
         // throw away constness and do an update!
         lock.unlock();
-        boost::unique_lock<boost::shared_mutex> uniqueLock(m_Lock);
+        std::unique_lock<std::shared_mutex> uniqueLock(m_Lock);
         const_cast<LocalizedRangeScan*>(this)->Update();
       }
 
@@ -5707,12 +5708,12 @@ namespace karto
      */
     inline const PointVectorDouble& GetPointReadings(kt_bool wantFiltered = false) const
     {
-      boost::shared_lock<boost::shared_mutex> lock(m_Lock);
+      std::shared_lock<std::shared_mutex> lock(m_Lock);
       if (m_IsDirty)
       {
         // throw away constness and do an update!
         lock.unlock();
-        boost::unique_lock<boost::shared_mutex> uniqueLock(m_Lock);
+        std::unique_lock<std::shared_mutex> uniqueLock(m_Lock);
         const_cast<LocalizedRangeScan*>(this)->Update();
       }
 

--- a/slam_toolbox/lib/karto_sdk/include/karto_sdk/Karto.h
+++ b/slam_toolbox/lib/karto_sdk/include/karto_sdk/Karto.h
@@ -5634,16 +5634,7 @@ namespace karto
      */
     void SetSensorPose(const Pose2& rScanPose)
     {
-      Pose2 deviceOffsetPose2 = GetLaserRangeFinder()->GetOffsetPose();
-      kt_double offsetLength = deviceOffsetPose2.GetPosition().Length();
-      kt_double offsetHeading = deviceOffsetPose2.GetHeading();
-      kt_double angleoffset = atan2(deviceOffsetPose2.GetY(), deviceOffsetPose2.GetX());
-      kt_double correctedHeading = math::NormalizeAngle(rScanPose.GetHeading());
-      Pose2 worldSensorOffset = Pose2(offsetLength * cos(correctedHeading + angleoffset - offsetHeading),
-                                      offsetLength * sin(correctedHeading + angleoffset - offsetHeading),
-                                      offsetHeading);
-
-      m_CorrectedPose = rScanPose - worldSensorOffset;
+      m_CorrectedPose = GetCorrectedAt(rScanPose);
 
       Update();
     }
@@ -5656,6 +5647,25 @@ namespace karto
     inline Pose2 GetSensorAt(const Pose2& rPose) const
     {
       return Transform(rPose).TransformPose(GetLaserRangeFinder()->GetOffsetPose());
+    }
+
+    /**
+     * @brief Computes the pose of the robot if the sensor were at the given pose
+     * @param sPose sensor pose
+     * @return robot pose
+     */
+    inline Pose2 GetCorrectedAt(const Pose2& sPose) const
+    {
+      Pose2 deviceOffsetPose2 = GetLaserRangeFinder()->GetOffsetPose();
+      kt_double offsetLength = deviceOffsetPose2.GetPosition().Length();
+      kt_double offsetHeading = deviceOffsetPose2.GetHeading();
+      kt_double angleoffset = atan2(deviceOffsetPose2.GetY(), deviceOffsetPose2.GetX());
+      kt_double correctedHeading = math::NormalizeAngle(sPose.GetHeading());
+      Pose2 worldSensorOffset = Pose2(offsetLength * cos(correctedHeading + angleoffset - offsetHeading),
+                                      offsetLength * sin(correctedHeading + angleoffset - offsetHeading),
+                                      offsetHeading);
+
+      return sPose - worldSensorOffset;
     }
 
     /**

--- a/slam_toolbox/lib/karto_sdk/include/karto_sdk/Karto.h
+++ b/slam_toolbox/lib/karto_sdk/include/karto_sdk/Karto.h
@@ -5572,6 +5572,17 @@ namespace karto
 
       m_IsDirty = true;
     }
+    
+    /**
+     * Moves the scan by moving the robot pose to the given location and update point readings.
+     * @param rPose new pose of the robot of this scan
+     */
+    inline void SetCorrectedPoseAndUpdate(const Pose2& rPose)
+    {
+      SetCorrectedPose(rPose);
+
+      Update();
+    }
 
     /**
      * Gets barycenter of point readings

--- a/slam_toolbox/lib/karto_sdk/src/Mapper.cpp
+++ b/slam_toolbox/lib/karto_sdk/src/Mapper.cpp
@@ -1607,9 +1607,9 @@ namespace karto
     // only attach link information if the edge is new
     if (isNewEdge == true)
     {
-      auto corrected_pose=pToScan->GetCorrectedPose();
+      Pose2 corrected_pose = pToScan->GetCorrectedPose();
       pToScan->SetSensorPose(rMean);
-      auto corrected_mean_pose=pToScan->GetCorrectedPose();
+      Pose2 corrected_mean_pose = pToScan->GetCorrectedPose();
       pToScan->SetCorrectedPose(corrected_pose);
       pEdge->SetLabel(new LinkInfo(pFromScan->GetCorrectedPose(), corrected_mean_pose, rCovariance));
       if (m_pMapper->m_pScanOptimizer != NULL)

--- a/slam_toolbox/lib/karto_sdk/src/Mapper.cpp
+++ b/slam_toolbox/lib/karto_sdk/src/Mapper.cpp
@@ -1990,7 +1990,7 @@ namespace karto
         {
           continue;
         }
-        scan->SetCorrectedPose(iter->second);
+        scan->SetCorrectedPoseAndUpdate(iter->second);
       }
 
       pSolver->Clear();

--- a/slam_toolbox/lib/karto_sdk/src/Mapper.cpp
+++ b/slam_toolbox/lib/karto_sdk/src/Mapper.cpp
@@ -1607,11 +1607,7 @@ namespace karto
     // only attach link information if the edge is new
     if (isNewEdge == true)
     {
-      Pose2 corrected_pose = pToScan->GetCorrectedPose();
-      pToScan->SetSensorPose(rMean);
-      Pose2 corrected_mean_pose = pToScan->GetCorrectedPose();
-      pToScan->SetCorrectedPose(corrected_pose);
-      pEdge->SetLabel(new LinkInfo(pFromScan->GetCorrectedPose(), corrected_mean_pose, rCovariance));
+      pEdge->SetLabel(new LinkInfo(pFromScan->GetCorrectedPose(), pToScan->GetCorrectedAt(rMean), rCovariance));
       if (m_pMapper->m_pScanOptimizer != NULL)
       {
         m_pMapper->m_pScanOptimizer->AddConstraint(pEdge);

--- a/slam_toolbox/lib/karto_sdk/src/Mapper.cpp
+++ b/slam_toolbox/lib/karto_sdk/src/Mapper.cpp
@@ -1607,7 +1607,11 @@ namespace karto
     // only attach link information if the edge is new
     if (isNewEdge == true)
     {
-      pEdge->SetLabel(new LinkInfo(pFromScan->GetSensorPose(), rMean, rCovariance));
+      auto corrected_pose=pToScan->GetCorrectedPose();
+      pToScan->SetSensorPose(rMean);
+      auto corrected_mean_pose=pToScan->GetCorrectedPose();
+      pToScan->SetCorrectedPose(corrected_pose);
+      pEdge->SetLabel(new LinkInfo(pFromScan->GetCorrectedPose(), corrected_mean_pose, rCovariance));
       if (m_pMapper->m_pScanOptimizer != NULL)
       {
         m_pMapper->m_pScanOptimizer->AddConstraint(pEdge);
@@ -1990,7 +1994,7 @@ namespace karto
         {
           continue;
         }
-        scan->SetSensorPose(iter->second);
+        scan->SetCorrectedPose(iter->second);
       }
 
       pSolver->Clear();


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (#180) |
| Primary OS tested on | (Ubuntu 20.04 ROS Noetic) |
| Robotic platform tested on | ([Handsfree mini](https://github.com/HANDS-FREE/handsfree)) |

---

## Description of contribution in a few bullet points

* I changed boost::shared_mutex, boost::shared_lock and boost::unique_lock with std::shared_mutex, std::shared_lock and std::unique_lock.
* That unexpected crash never happens to my robot again.

## Description of documentation updates required from your changes

* Change the compile standard from c++11 to c++17.

---
## Future work that may be required in bullet points
* I don't have a ROS2 robot yet. Is anyone there be kind to test this modification on a ROS2 robot?