### PR TITLE
fix issue (#180) that localization mode may terminate unexpectedly with exception about pthread_mutex_lock

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project(slam_toolbox)
 
 set(CMAKE_BUILD_TYPE Release) #None, Debug, Release, RelWithDebInfo, MinSizeRel
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD 17)
 endif()
 cmake_policy(SET CMP0077 NEW)
 

--- a/include/slam_toolbox/visualization_utils.hpp
+++ b/include/slam_toolbox/visualization_utils.hpp
@@ -50,7 +50,7 @@ inline visualization_msgs::msg::Marker toMarker(
   marker.color.b = 0.0;
   marker.color.a = 1.;
   marker.action = visualization_msgs::msg::Marker::ADD;
-  marker.lifetime = rclcpp::Duration::from_nanoseconds(0);
+  marker.lifetime = rclcpp::Duration::from_seconds(0);
 
   return marker;
 }

--- a/lib/karto_sdk/CMakeLists.txt
+++ b/lib/karto_sdk/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.5)
 project(karto_sdk)
 
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD 17)
 endif()
 set(CMAKE_BUILD_TYPE Release) #None, Debug, Release, RelWithDebInfo, MinSizeRel
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ftemplate-backtrace-limit=0")

--- a/lib/karto_sdk/include/karto_sdk/Karto.h
+++ b/lib/karto_sdk/include/karto_sdk/Karto.h
@@ -49,6 +49,7 @@
 #include <iomanip>
 #include <sstream>
 #include <stdexcept>
+#include <shared_mutex>
 
 #ifdef USE_POCO
 #include <Poco/Mutex.h>
@@ -5434,7 +5435,7 @@ public:
   }
 
 private:
-  mutable boost::shared_mutex m_Lock;
+  mutable std::shared_mutex m_Lock;
 
 public:
   /**
@@ -5495,11 +5496,11 @@ public:
    */
   inline const Pose2 & GetBarycenterPose() const
   {
-    boost::shared_lock<boost::shared_mutex> lock(m_Lock);
+    std::shared_lock<std::shared_mutex> lock(m_Lock);
     if (m_IsDirty) {
       // throw away constness and do an update!
       lock.unlock();
-      boost::unique_lock<boost::shared_mutex> uniqueLock(m_Lock);
+      std::unique_lock<std::shared_mutex> uniqueLock(m_Lock);
       const_cast<LocalizedRangeScan *>(this)->Update();
     }
 
@@ -5518,11 +5519,11 @@ public:
    */
   inline Pose2 GetReferencePose(kt_bool useBarycenter) const
   {
-    boost::shared_lock<boost::shared_mutex> lock(m_Lock);
+    std::shared_lock<std::shared_mutex> lock(m_Lock);
     if (m_IsDirty) {
       // throw away constness and do an update!
       lock.unlock();
-      boost::unique_lock<boost::shared_mutex> uniqueLock(m_Lock);
+      std::unique_lock<std::shared_mutex> uniqueLock(m_Lock);
       const_cast<LocalizedRangeScan *>(this)->Update();
     }
 
@@ -5589,11 +5590,11 @@ public:
    */
   inline const BoundingBox2 & GetBoundingBox() const
   {
-    boost::shared_lock<boost::shared_mutex> lock(m_Lock);
+    std::shared_lock<std::shared_mutex> lock(m_Lock);
     if (m_IsDirty) {
       // throw away constness and do an update!
       lock.unlock();
-      boost::unique_lock<boost::shared_mutex> uniqueLock(m_Lock);
+      std::unique_lock<std::shared_mutex> uniqueLock(m_Lock);
       const_cast<LocalizedRangeScan *>(this)->Update();
     }
 
@@ -5610,11 +5611,11 @@ public:
    */
   inline const PointVectorDouble & GetPointReadings(kt_bool wantFiltered = false) const
   {
-    boost::shared_lock<boost::shared_mutex> lock(m_Lock);
+    std::shared_lock<std::shared_mutex> lock(m_Lock);
     if (m_IsDirty) {
       // throw away constness and do an update!
       lock.unlock();
-      boost::unique_lock<boost::shared_mutex> uniqueLock(m_Lock);
+      std::unique_lock<std::shared_mutex> uniqueLock(m_Lock);
       const_cast<LocalizedRangeScan *>(this)->Update();
     }
 


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (#180) |
| Primary OS tested on | (Ubuntu 20.04 ROS Noetic) |
| Robotic platform tested on | ([Handsfree mini](https://github.com/HANDS-FREE/handsfree)) |

---

## Description of contribution in a few bullet points

* I changed boost::shared_mutex, boost::shared_lock and boost::unique_lock with std::shared_mutex, std::shared_lock and std::unique_lock.
* That unexpected crash never happens to my robot again.

## Description of documentation updates required from your changes

* Change the compile standard from c++14 to c++17.

---

## Future work that may be required in bullet points

* Please test this commit with ROS2.
