### PR TITLE
Remove outdated ceres parameters [foxy]

### DIFF
--- a/solvers/ceres_solver.cpp
+++ b/solvers/ceres_solver.cpp
@@ -341,6 +341,9 @@ void CeresSolver::RemoveNode(kt_int32s id)
   boost::mutex::scoped_lock lock(nodes_mutex_);
   GraphIterator nodeit = nodes_->find(id);
   if (nodeit != nodes_->end()) {
+    problem_->RemoveParameterBlock(&nodeit->second(0));
+    problem_->RemoveParameterBlock(&nodeit->second(1));
+    problem_->RemoveParameterBlock(&nodeit->second(2));
     nodes_->erase(nodeit);
   } else {
     RCLCPP_ERROR(node_->get_logger(), "RemoveNode: Failed to find node matching id %i",


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #398 |
| Primary OS tested on | Ubuntu 20.04 |
| Robotic platform tested on | Gazebo simulation, custom robot platform |

---

## Description of contribution in a few bullet points
This PR fixes occasional failures of the Ceres solver to produce a valid solution due to invalid parameter blocks in localization mode.
Parameter blocks from expired nodes are now explicitly removed from the solver .


## Description of documentation updates required from your changes
No documentation changes required

---

## Future work that may be required in bullet points

While fixing this bug I found that according to Ceres documentation even when the `Residual Blocks` and `Parameter Blocks `are removed from the problem, the dependent parameterization, cost and loss functions will exist until the problem itself is deleted (https://github.com/ceres-solver/ceres-solver/blob/ec4f2995bbde911d6861fb5c9bb7353ad796e02b/include/ceres/problem.h#L294:297)
As localization has to run potentially for a long time it might be interesting to see if we are "leaking" memory here.

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->
