### PR TITLE
Added Service response structure for save map and serialize Posegraph

### DIFF
--- a/include/slam_toolbox/serialization.hpp
+++ b/include/slam_toolbox/serialization.hpp
@@ -34,7 +34,7 @@ inline bool fileExists(const std::string & name)
   return stat(name.c_str(), &buffer) == 0;
 }
 
-inline void write(
+inline bool write(
   const std::string & filename,
   karto::Mapper & mapper,
   karto::Dataset & dataset,
@@ -43,9 +43,11 @@ inline void write(
   try {
     mapper.SaveToFile(filename + std::string(".posegraph"));
     dataset.SaveToFile(filename + std::string(".data"));
+    return true;
   } catch (boost::archive::archive_exception e) {
     RCLCPP_ERROR(node->get_logger(),
       "Failed to write file: Exception %s", e.what());
+    return false;
   }
 }
 

--- a/src/map_saver.cpp
+++ b/src/map_saver.cpp
@@ -65,9 +65,6 @@ bool MapSaver::saveMapCallback(
     if (rc == 0) {
       response->result = response->RESULT_SUCCESS;
     }
-    else if (rc == 64000) {
-      response->result = response->RESULT_SEGMENTATION_FAULT;
-    }
     else {
       response->result = response->RESULT_UNDEFINED_FAILURE;
     }
@@ -78,9 +75,6 @@ bool MapSaver::saveMapCallback(
     int rc = system("ros2 run nav2_map_server map_saver_cli --ros-args -p map_subscribe_transient_local:=true");
     if (rc == 0) {
       response->result = response->RESULT_SUCCESS;
-    }
-    else if (rc == 64000) {
-      response->result = response->RESULT_SEGMENTATION_FAULT;
     }
     else {
       response->result = response->RESULT_UNDEFINED_FAILURE;

--- a/src/map_saver.cpp
+++ b/src/map_saver.cpp
@@ -53,6 +53,7 @@ bool MapSaver::saveMapCallback(
     RCLCPP_WARN(node_->get_logger(),
       "Map Saver: Cannot save map, no map yet received on topic %s.",
       map_name_.c_str());
+    response->result = response->RESULT_NO_MAP_RECEIEVD;
     return false;
   }
 
@@ -61,10 +62,29 @@ bool MapSaver::saveMapCallback(
     RCLCPP_INFO(node_->get_logger(),
       "SlamToolbox: Saving map as %s.", name.c_str());
     int rc = system(("ros2 run nav2_map_server map_saver_cli -f " + name  + " --ros-args -p map_subscribe_transient_local:=true").c_str());
+    if (rc == 0) {
+      response->result = response->RESULT_SUCCESS;
+    }
+    else if (rc == 64000) {
+      response->result = response->RESULT_SEGMENTATION_FAULT;
+    }
+    else {
+      response->result = response->RESULT_UNDEFINED_FAILURE;
+    }
+
   } else {
     RCLCPP_INFO(node_->get_logger(),
       "SlamToolbox: Saving map in current directory.");
     int rc = system("ros2 run nav2_map_server map_saver_cli --ros-args -p map_subscribe_transient_local:=true");
+    if (rc == 0) {
+      response->result = response->RESULT_SUCCESS;
+    }
+    else if (rc == 64000) {
+      response->result = response->RESULT_SEGMENTATION_FAULT;
+    }
+    else {
+      response->result = response->RESULT_UNDEFINED_FAILURE;
+    }
   }
 
   rclcpp::sleep_for(std::chrono::seconds(1));

--- a/src/map_saver.cpp
+++ b/src/map_saver.cpp
@@ -64,19 +64,16 @@ bool MapSaver::saveMapCallback(
     int rc = system(("ros2 run nav2_map_server map_saver_cli -f " + name  + " --ros-args -p map_subscribe_transient_local:=true").c_str());
     if (rc == 0) {
       response->result = response->RESULT_SUCCESS;
-    }
-    else {
+    } else {
       response->result = response->RESULT_UNDEFINED_FAILURE;
     }
-
   } else {
     RCLCPP_INFO(node_->get_logger(),
       "SlamToolbox: Saving map in current directory.");
     int rc = system("ros2 run nav2_map_server map_saver_cli --ros-args -p map_subscribe_transient_local:=true");
     if (rc == 0) {
       response->result = response->RESULT_SUCCESS;
-    }
-    else {
+    } else {
       response->result = response->RESULT_UNDEFINED_FAILURE;
     }
   }

--- a/src/slam_toolbox_common.cpp
+++ b/src/slam_toolbox_common.cpp
@@ -640,6 +640,7 @@ bool SlamToolbox::serializePoseGraphCallback(
   boost::mutex::scoped_lock lock(smapper_mutex_);
   serialization::write(filename, *smapper_->getMapper(),
     *dataset_, shared_from_this());
+  resp->result = resp->RESULT_SUCCESS;
   return true;
 }
 

--- a/src/slam_toolbox_common.cpp
+++ b/src/slam_toolbox_common.cpp
@@ -638,9 +638,13 @@ bool SlamToolbox::serializePoseGraphCallback(
   }
 
   boost::mutex::scoped_lock lock(smapper_mutex_);
-  serialization::write(filename, *smapper_->getMapper(),
-    *dataset_, shared_from_this());
-  resp->result = resp->RESULT_SUCCESS;
+  if (serialization::write(filename, *smapper_->getMapper(),*dataset_, shared_from_this())) {
+    resp->result = resp->RESULT_SUCCESS;
+  }
+  else {
+    resp->result = resp->RESULT_FAILED_TO_WRITE_FILE;
+  }
+
   return true;
 }
 

--- a/src/slam_toolbox_common.cpp
+++ b/src/slam_toolbox_common.cpp
@@ -638,10 +638,9 @@ bool SlamToolbox::serializePoseGraphCallback(
   }
 
   boost::mutex::scoped_lock lock(smapper_mutex_);
-  if (serialization::write(filename, *smapper_->getMapper(),*dataset_, shared_from_this())) {
+  if (serialization::write(filename, *smapper_->getMapper(), *dataset_, shared_from_this())) {
     resp->result = resp->RESULT_SUCCESS;
-  }
-  else {
+  } else {
     resp->result = resp->RESULT_FAILED_TO_WRITE_FILE;
   }
 

--- a/srvs/SaveMap.srv
+++ b/srvs/SaveMap.srv
@@ -1,2 +1,9 @@
 std_msgs/String name
 ---
+# Result code defintions
+uint8 RESULT_SUCCESS=0
+uint8 RESULT_SEGMENTATION_FAULT=1
+uint8 RESULT_NO_MAP_RECEIEVD=2
+uint8 RESULT_UNDEFINED_FAILURE=255
+
+uint8 result

--- a/srvs/SaveMap.srv
+++ b/srvs/SaveMap.srv
@@ -2,8 +2,7 @@ std_msgs/String name
 ---
 # Result code defintions
 uint8 RESULT_SUCCESS=0
-uint8 RESULT_SEGMENTATION_FAULT=1
-uint8 RESULT_NO_MAP_RECEIEVD=2
+uint8 RESULT_NO_MAP_RECEIEVD=1
 uint8 RESULT_UNDEFINED_FAILURE=255
 
 uint8 result

--- a/srvs/SerializePoseGraph.srv
+++ b/srvs/SerializePoseGraph.srv
@@ -1,2 +1,7 @@
 string filename
 ---
+# Result code defintions
+uint8 RESULT_SUCCESS=0
+uint8 RESULT_UNDEFINED_FAILURE=255
+
+uint8 result

--- a/srvs/SerializePoseGraph.srv
+++ b/srvs/SerializePoseGraph.srv
@@ -2,6 +2,6 @@ string filename
 ---
 # Result code defintions
 uint8 RESULT_SUCCESS=0
-uint8 RESULT_UNDEFINED_FAILURE=255
+uint8 RESULT_FAILED_TO_WRITE_FILE=255
 
 uint8 result


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #420  |
| Primary OS tested on | Ubuntu 20.04 ROS2 Foxy |

---

## Description of contribution in a few bullet points

- I added response structure in service messages `(SaveMap.srv, SerializePoseGraph.srv)` and service response in `MapSaver::saveMapCallback` and `SlamToolbox::serializePoseGraphCallback`

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->
