### PR TITLE
Correct Rolling compile errors and warnings

### DIFF
--- a/include/slam_toolbox/loop_closure_assistant.hpp
+++ b/include/slam_toolbox/loop_closure_assistant.hpp
@@ -26,6 +26,7 @@
 #include <map>
 
 #include "tf2_ros/transform_broadcaster.h"
+#include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
 #include "tf2/utils.h"
 #include "rclcpp/rclcpp.hpp"
 #include "interactive_markers/interactive_marker_server.hpp"

--- a/include/slam_toolbox/slam_mapper.hpp
+++ b/include/slam_toolbox/slam_mapper.hpp
@@ -20,7 +20,9 @@
 #define SLAM_TOOLBOX__SLAM_MAPPER_HPP_
 
 #include <memory>
+#include "geometry_msgs/msg/quaternion.hpp"
 #include "rclcpp/rclcpp.hpp"
+#include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
 #include "tf2/utils.h"
 #include "slam_toolbox/toolbox_types.hpp"
 

--- a/src/experimental/slam_toolbox_lifelong_node.cpp
+++ b/src/experimental/slam_toolbox_lifelong_node.cpp
@@ -27,7 +27,7 @@ int main(int argc, char ** argv)
   int stack_size = 40000000;
   {
     auto temp_node = std::make_shared<rclcpp::Node>("slam_toolbox");
-    temp_node->declare_parameter("stack_size_to_use");
+    temp_node->declare_parameter("stack_size_to_use", stack_size);
     if (temp_node->get_parameter("stack_size_to_use", stack_size)) {
       RCLCPP_INFO(temp_node->get_logger(), "Node using stack size %i", (int)stack_size);
       const rlim_t max_stack_size = stack_size;

--- a/src/loop_closure_assistant.cpp
+++ b/src/loop_closure_assistant.cpp
@@ -21,6 +21,8 @@
 
 #include "slam_toolbox/loop_closure_assistant.hpp"
 
+#include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
+
 namespace loop_closure_assistant
 {
 


### PR DESCRIPTION
This PR contains trivial changes, mostly about missing includes, to get ros2 branch compiled under rolling.
I also resolve a deprecation warning about `declare_parameter` without a value.
