### PR TITLE
Add no_tcpdelay_for_scan_topic parameter

### DIFF
--- a/slam_toolbox/config/mapper_params_lifelong.yaml
+++ b/slam_toolbox/config/mapper_params_lifelong.yaml
@@ -11,6 +11,7 @@ odom_frame: odom
 map_frame: map
 base_frame: base_footprint
 scan_topic: /scan
+no_tcpdelay_on_scan_topic: false
 mode: mapping
 
 # lifelong params

--- a/slam_toolbox/config/mapper_params_localization.yaml
+++ b/slam_toolbox/config/mapper_params_localization.yaml
@@ -11,6 +11,7 @@ odom_frame: odom
 map_frame: map
 base_frame: base_footprint
 scan_topic: /scan
+no_tcpdelay_on_scan_topic: false
 mode: mapping #localization
 
 # if you'd like to start localizing on bringup in a map and pose

--- a/slam_toolbox/config/mapper_params_offline.yaml
+++ b/slam_toolbox/config/mapper_params_offline.yaml
@@ -11,6 +11,7 @@ odom_frame: odom
 map_frame: map
 base_frame: base_link
 scan_topic: /scan
+no_tcpdelay_on_scan_topic: false
 mode: mapping #localization
 debug_logging: false
 throttle_scans: 1

--- a/slam_toolbox/config/mapper_params_online_async.yaml
+++ b/slam_toolbox/config/mapper_params_online_async.yaml
@@ -11,6 +11,7 @@ odom_frame: odom
 map_frame: map
 base_frame: base_footprint
 scan_topic: /scan
+no_tcpdelay_on_scan_topic: false
 mode: mapping #localization
 
 # if you'd like to immediately start continuing a map at a given pose

--- a/slam_toolbox/config/mapper_params_online_sync.yaml
+++ b/slam_toolbox/config/mapper_params_online_sync.yaml
@@ -11,6 +11,7 @@ odom_frame: odom
 map_frame: map
 base_frame: base_footprint
 scan_topic: /scan
+no_tcpdelay_on_scan_topic: false
 mode: mapping #localization
 
 # if you'd like to immediately start continuing a map at a given pose

--- a/slam_toolbox/include/slam_toolbox/slam_toolbox_common.hpp
+++ b/slam_toolbox/include/slam_toolbox/slam_toolbox_common.hpp
@@ -114,7 +114,7 @@ protected:
   int throttle_scans_;
 
   double resolution_;
-  bool first_measurement_, enable_interactive_mode_;
+  bool first_measurement_, enable_interactive_mode_, no_tcpdelay_on_scan_topic_;
 
   // Book keeping
   std::unique_ptr<mapper_utils::SMapper> smapper_;

--- a/slam_toolbox/src/slam_toolbox_common.cpp
+++ b/slam_toolbox/src/slam_toolbox_common.cpp
@@ -115,6 +115,7 @@ void SlamToolbox::setParams(ros::NodeHandle& private_nh)
   private_nh.param("resolution", resolution_, 0.05);
   private_nh.param("map_name", map_name_, std::string("/map"));
   private_nh.param("scan_topic", scan_topic_, std::string("/scan"));
+  private_nh.param("no_tcpdelay_on_scan_topic", no_tcpdelay_on_scan_topic_, false);
   private_nh.param("throttle_scans", throttle_scans_, 1);
   private_nh.param("enable_interactive_mode", enable_interactive_mode_, false);
 
@@ -153,6 +154,9 @@ void SlamToolbox::setROSInterfaces(ros::NodeHandle& node)
   ssPauseMeasurements_ = node.advertiseService("pause_new_measurements", &SlamToolbox::pauseNewMeasurementsCallback, this);
   ssSerialize_ = node.advertiseService("serialize_map", &SlamToolbox::serializePoseGraphCallback, this);
   ssDesserialize_ = node.advertiseService("deserialize_map", &SlamToolbox::deserializePoseGraphCallback, this);
+  ros::TransportHints transport_hints{};
+  transport_hints.tcpNoDelay(no_tcpdelay_on_scan_topic_);
+  scan_filter_sub_ = std::make_unique<message_filters::Subscriber<sensor_msgs::LaserScan>>(node, scan_topic_, 5, transport_hints);
   scan_filter_sub_ = std::make_unique<message_filters::Subscriber<sensor_msgs::LaserScan> >(node, scan_topic_, 5);
   scan_filter_ = std::make_unique<tf2_ros::MessageFilter<sensor_msgs::LaserScan> >(*scan_filter_sub_, *tf_, odom_frame_, 5, node);
   scan_filter_->registerCallback(boost::bind(&SlamToolbox::laserCallback, this, _1));


### PR DESCRIPTION
---

## Adding parameter to be able to remove occasional delay in scan topic

| Info | Add parameter to disable nagle's algorithm in tcp communication |
| ------ | ----------- |
| Ticket(s) this addresses   | ... |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | ... |

---

## Description of contribution in a few bullet points

* I added a no_tcpdelay_on_scan_topic parameter
* This parameter gets passed to the scan topic subscriber as a transport hint
* This disables the nagle's algorithm which otherwise causes a jitter of about 20ms in the scan topic

## Description of documentation updates required from your changes

* Added new parameter, so need to add that to default configs and documentation page
---

## Future work that may be required in bullet points

* I did notice, that changing the order of imports in slam_toolbox_common.hpp to be alphabetically results in an build error due to getYaw double declaration in tf and tf2. Someone might want to investigate that ^^


## Reason
During the investigation of some artifacts in maps generated with our scanner we realized the 20ms jitter in the ros topic and were able to trace the origin back to the nagle's algorithm. This is some tcp optimization which basically holds smaller massages back as long as other messages are still not confirmed. This algorithm can in cpp only be deactivated by the subscriber => in for example the slam_toolbox. 
This jitter was in the end not the reason for those artefacts in the map generation, but we are still wondering if you ever considered if or how it affects the localization and or map generation.