### PR TITLE
Reverted solver blocks removal that crashes multiple initial poses [foxy]

### DIFF
--- a/solvers/ceres_solver.cpp
+++ b/solvers/ceres_solver.cpp
@@ -341,9 +341,6 @@ void CeresSolver::RemoveNode(kt_int32s id)
   boost::mutex::scoped_lock lock(nodes_mutex_);
   GraphIterator nodeit = nodes_->find(id);
   if (nodeit != nodes_->end()) {
-    problem_->RemoveParameterBlock(&nodeit->second(0));
-    problem_->RemoveParameterBlock(&nodeit->second(1));
-    problem_->RemoveParameterBlock(&nodeit->second(2));
     nodes_->erase(nodeit);
   } else {
     RCLCPP_ERROR(node_->get_logger(), "RemoveNode: Failed to find node matching id %i",


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #419  |
| Primary OS tested on | Ubuntu 20.04, ROS2 Foxy |
| Robotic platform tested on | Custom diff drive real robot |

---

## Description of contribution in a few bullet points
Fixed crashes when setting initial poses, but may re-introduce warnings these lines avoided.


## Description of documentation updates required from your changes
N/A

---

## Future work that may be required in bullet points
As mentioned in the ticket's discussion this fixes the issue until a "better scan management" is implemented.
