### PR TITLE
Reverted solver blocks removal that crashes multiple initial poses [ros2]

### DIFF
--- a/solvers/ceres_solver.cpp
+++ b/solvers/ceres_solver.cpp
@@ -341,9 +341,6 @@ void CeresSolver::RemoveNode(kt_int32s id)
   boost::mutex::scoped_lock lock(nodes_mutex_);
   GraphIterator nodeit = nodes_->find(id);
   if (nodeit != nodes_->end()) {
-    problem_->RemoveParameterBlock(&nodeit->second(0));
-    problem_->RemoveParameterBlock(&nodeit->second(1));
-    problem_->RemoveParameterBlock(&nodeit->second(2));
     nodes_->erase(nodeit);
   } else {
     RCLCPP_ERROR(node_->get_logger(), "RemoveNode: Failed to find node matching id %i",


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #419 #441 |
| Primary OS tested on | N/A |
| Robotic platform tested on | N/A |

---

Accompanying  #441 to  merge across the several branches concerned. 