### PR TITLE
Fix for use-after-free that causes unpredicable crashes on serialization

### DIFF
--- a/slam_toolbox/lib/karto_sdk/include/karto_sdk/Mapper.h
+++ b/slam_toolbox/lib/karto_sdk/include/karto_sdk/Mapper.h
@@ -1465,6 +1465,7 @@ namespace karto
       , m_pCorrelationGrid(NULL)
       , m_pSearchSpaceProbs(NULL)
       , m_pGridLookup(NULL)
+      , m_pPoseResponse(NULL)
       , m_doPenalize(false)
     {
     }
@@ -1501,12 +1502,26 @@ namespace karto
       ar & BOOST_SERIALIZATION_NVP(m_nAngles);
       ar & BOOST_SERIALIZATION_NVP(m_searchAngleResolution);;
       ar & BOOST_SERIALIZATION_NVP(m_doPenalize);
-      kt_int32u poseResponseSize = static_cast<kt_int32u>(m_xPoses.size() * m_yPoses.size() * m_nAngles);
-      if (Archive::is_loading::value)
-      {
-        m_pPoseResponse = new std::pair<kt_double, Pose2>[poseResponseSize];
-      }
-      ar & boost::serialization::make_array<std::pair<kt_double, Pose2>>(m_pPoseResponse, poseResponseSize);
+      
+      // Note - m_pPoseResponse is generally only ever defined within the
+      // execution of ScanMatcher::CorrelateScan and used as a temporary
+      // accumulator for multithreaded matching results. It would normally
+      // not make sense to serialize, but we don't want to break compatibility
+      // with previously serialized data. Gen some dummy data that we free
+      // immediately after so that we don't alloc here and leak.
+      kt_int32u poseResponseSize =
+        static_cast<kt_int32u>(m_xPoses.size() * m_yPoses.size() * m_nAngles);
+
+      // We could check first if m_pPoseResponse == nullptr for good measure, but
+      // based on the codepaths it should always be freed and set to null outside of
+      // any execution of ScanMatcher::CorrelateScan, so go ahead and alloc here.
+      m_pPoseResponse = new std::pair<kt_double, Pose2>[poseResponseSize];
+      ar & boost::serialization::make_array<std::pair<kt_double, Pose2>>(m_pPoseResponse,
+        poseResponseSize);
+
+      // Aaaand now, clean up the dummy data
+      delete[] m_pPoseResponse;
+      m_pPoseResponse = nullptr;
     }
 
   };  // ScanMatcher

--- a/slam_toolbox/lib/karto_sdk/src/Mapper.cpp
+++ b/slam_toolbox/lib/karto_sdk/src/Mapper.cpp
@@ -845,6 +845,7 @@ namespace karto
 
     // delete pose response array
     delete [] m_pPoseResponse;
+    m_pPoseResponse = nullptr;
 
 #ifdef KARTO_DEBUG
     std::cout << "bestPose: " << averagePose << std::endl;


### PR DESCRIPTION
---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #393  |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Ohmni robots  |

---

## Description of contribution in a few bullet points

* Explicitly set m_pPoseResponse to NULL in the ScanMatcher constructor (following existing convention there which is why not using nullptr)
* Set m_pPoseResponse to nullptr after delete[] is called to avoid keeping a stale reference to a free'd block
* Modify logic in ScanMatcher::serialize to basically serialize to and from some dummy data that we new and free, since the serialized data is not relevant for operation anyways.

## Description of documentation updates required from your changes

None required.

---

## Future work that may be required in bullet points

None.
