### PR TITLE
Fixed error in relative imports.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,7 +84,8 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 add_definitions(-DQT_NO_KEYWORDS)
 find_package(Boost REQUIRED system serialization filesystem thread)
 
-include_directories(include ${EIGEN3_INCLUDE_DIRS}
+include_directories(include lib/karto_sdk/include
+                            ${EIGEN3_INCLUDE_DIRS}
                             ${CHOLMOD_INCLUDE_DIR}
                             ${Boost_INCLUDE_DIRS}
                             ${TBB_INCLUDE_DIRS}

--- a/include/slam_toolbox/get_pose_helper.hpp
+++ b/include/slam_toolbox/get_pose_helper.hpp
@@ -22,7 +22,7 @@
 #include <string>
 #include "geometry_msgs/msg/pose_with_covariance_stamped.hpp"
 #include "slam_toolbox/toolbox_types.hpp"
-#include "../lib/karto_sdk/include/karto_sdk/Mapper.h"
+#include "karto_sdk/Mapper.h"
 
 namespace pose_utils
 {

--- a/include/slam_toolbox/serialization.hpp
+++ b/include/slam_toolbox/serialization.hpp
@@ -23,7 +23,7 @@
 #include <vector>
 #include <string>
 #include "rclcpp/rclcpp.hpp"
-#include "../lib/karto_sdk/include/karto_sdk/Mapper.h"
+#include "karto_sdk/Mapper.h"
 
 namespace serialization
 {

--- a/include/slam_toolbox/toolbox_types.hpp
+++ b/include/slam_toolbox/toolbox_types.hpp
@@ -27,8 +27,7 @@
 #include "tf2_geometry_msgs/tf2_geometry_msgs.h"
 #include "tf2/transform_datatypes.h"
 
-// god... getting this to work in ROS2 was a real pain
-#include "../lib/karto_sdk/include/karto_sdk/Mapper.h"
+#include "karto_sdk/Mapper.h"
 #include "slam_toolbox/toolbox_msgs.hpp"
 
 // compute linear index for given map coords

--- a/lib/karto_sdk/CMakeLists.txt
+++ b/lib/karto_sdk/CMakeLists.txt
@@ -18,8 +18,7 @@ set(dependencies
   rclcpp
 )
 
-include_directories(include ${catkin_INCLUDE_DIRS} 
-                            ${EIGEN3_INCLUDE_DIRS} 
+include_directories(include ${EIGEN3_INCLUDE_DIRS} 
                             ${Boost_INCLUDE_DIR}
                             ${BOOST_INCLUDE_DIRS}
                             ${TBB_INCLUDE_DIRS}
@@ -27,7 +26,7 @@ include_directories(include ${catkin_INCLUDE_DIRS}
 
 add_definitions(${EIGEN3_DEFINITIONS})
 
-include_directories(include ${catkin_INCLUDE_DIRS} ${EIGEN3_INCLUDE_DIRS} ${TBB_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
+include_directories(include ${EIGEN3_INCLUDE_DIRS} ${TBB_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
 add_library(kartoSlamToolbox SHARED src/Karto.cpp src/Mapper.cpp)
 ament_target_dependencies(kartoSlamToolbox ${dependencies})
 target_link_libraries(kartoSlamToolbox ${Boost_LIBRARIES} ${TBB_LIBRARIES})

--- a/solvers/ceres_solver.hpp
+++ b/solvers/ceres_solver.hpp
@@ -13,13 +13,12 @@
 #include <unordered_map>
 #include <utility>
 #include <cmath>
-// god... getting this to work in ROS2 was a real pain
-#include "../lib/karto_sdk/include/karto_sdk/Mapper.h"
+#include "karto_sdk/Mapper.h"
 #include "solvers/ceres_utils.h"
 
 #include "rclcpp/rclcpp.hpp"
 #include "std_srvs/srv/empty.hpp"
-#include "../include/slam_toolbox/toolbox_types.hpp"
+#include "slam_toolbox/toolbox_types.hpp"
 
 namespace solver_plugins
 {


### PR DESCRIPTION
---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #471 |
| Primary OS tested on | Ubuntu 20.04 |
| Robotic platform tested on | None, this is a build-time problem only |

---

## Description of contribution in a few bullet points

* I changed the relative imports to absolute ones that work on the package itself and when including from other packages.
* Removed `$catkin_INCLUDE_DIRS` from CMakeLists.txt as this is not needed in ROS2/ament (see https://docs.ros.org/en/foxy/Contributing/Migration-Guide.html).
* Removed the "god... getting this to work in ROS2 was a real pain" because the previous solution didn't get it to fully work. I also believe no notice is needed now because the solution is standard.

## Description of documentation updates required from your changes

None, as far as I know.

---

## Future work that may be required in bullet points

None, as far as I know.