### PR TITLE
Fixing error in residual scaling.

### DIFF
--- a/solvers/ceres_solver.cpp
+++ b/solvers/ceres_solver.cpp
@@ -310,13 +310,14 @@ void CeresSolver::AddConstraint(karto::Edge<karto::LocalizedRangeScan> * pEdge)
   Eigen::Vector3d pose2d(diff.GetX(), diff.GetY(), diff.GetHeading());
 
   karto::Matrix3 precisionMatrix = pLinkInfo->GetCovariance().Inverse();
-  Eigen::Matrix3d sqrt_information;
-  sqrt_information(0, 0) = precisionMatrix(0, 0);
-  sqrt_information(0, 1) = sqrt_information(1, 0) = precisionMatrix(0, 1);
-  sqrt_information(0, 2) = sqrt_information(2, 0) = precisionMatrix(0, 2);
-  sqrt_information(1, 1) = precisionMatrix(1, 1);
-  sqrt_information(1, 2) = sqrt_information(2, 1) = precisionMatrix(1, 2);
-  sqrt_information(2, 2) = precisionMatrix(2, 2);
+  Eigen::Matrix3d information;
+  information(0, 0) = precisionMatrix(0, 0);
+  information(0, 1) = information(1, 0) = precisionMatrix(0, 1);
+  information(0, 2) = information(2, 0) = precisionMatrix(0, 2);
+  information(1, 1) = precisionMatrix(1, 1);
+  information(1, 2) = information(2, 1) = precisionMatrix(1, 2);
+  information(2, 2) = precisionMatrix(2, 2);
+  Eigen::Matrix3d sqrt_information = information.llt().matrixU();
 
   // populate residual and parameterization for heading normalization
   ceres::CostFunction * cost_function = PoseGraph2dErrorTerm::Create(pose2d(0),


### PR DESCRIPTION
---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #473 |
| Primary OS tested on | Ubuntu 20.04 |
| Robotic platform tested on | turtlebot3_gazebo, with the house world |

---

## Description of contribution in a few bullet points
* Corrected the residual scaling. 

I tested this in simulation and a few datasets and achieved good results. This might change some results or backend configurations, but I think it is more coherent with the scan matcher. In the end, the final uncertainty bounds attained depend on the tuning of the underlying probability model, which is heavily influenced by the covariance the scan matcher assigns.

## Description of documentation updates required from your changes
None. 

## Future work that may be required in bullet points
None. 
