### PR TITLE
Fix bug when load an one-node pose graph.

### DIFF
--- a/solvers/ceres_solver.cpp
+++ b/solvers/ceres_solver.cpp
@@ -177,7 +177,10 @@ void CeresSolver::Compute()
   }
 
   // populate contraint for static initial pose
-  if (!was_constant_set_ && first_node_ != nodes_->end()) {
+  if (!was_constant_set_ && first_node_ != nodes_->end() &&
+      problem_->HasParameterBlock(&first_node_->second(0)) &&
+      problem_->HasParameterBlock(&first_node_->second(1)) &&
+      problem_->HasParameterBlock(&first_node_->second(2))) {
     RCLCPP_DEBUG(node_->get_logger(),
       "CeresSolver: Setting first node as a constant pose:"
       "%0.2f, %0.2f, %0.2f.", first_node_->second(0),


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | N/A |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | (gazebo simulation of turtlebot) |

---

## Description of contribution in a few bullet points

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

Fixed the bug of ceres-solver plugin that when load a one-node pose graph.

Although such a one-node pose graph is not normally loaded, this is really a bug that can crash the program. When a pose-graph only contain one node, which means that there is no constraint has been add in ceres problem. In this suitation `problem_->SetParameterBlockConstant` will abort the program.

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

N/A

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

N/A