### PR TITLE
Add graph edges to graph visualization marker.

### DIFF
--- a/src/loop_closure_assistant.cpp
+++ b/src/loop_closure_assistant.cpp
@@ -178,6 +178,35 @@ void LoopClosureAssistant::publishGraph()
     }
   }
 
+  // add line markers for graph edges
+  auto edges = mapper_->GetGraph()->GetEdges();
+  visualization_msgs::msg::Marker edges_marker;
+  edges_marker.header.frame_id = map_frame_;
+  edges_marker.header.stamp = node_->now();
+  edges_marker.ns = "slam_toolbox_edges";
+  edges_marker.action = visualization_msgs::msg::Marker::ADD;
+  edges_marker.type = visualization_msgs::msg::Marker::LINE_LIST;
+  edges_marker.pose.orientation.w = 1;
+  edges_marker.scale.x = 0.05;
+  edges_marker.color.b = 1;
+  edges_marker.color.a = 1;
+  edges_marker.lifetime = rclcpp::Duration::from_seconds(0);
+  edges_marker.points.reserve(edges.size() * 2);
+  for (const auto& edge: edges) {
+      const auto& pose0 = edge->GetSource()->GetObject()->GetCorrectedPose();
+      geometry_msgs::msg::Point p0;
+      p0.x = pose0.GetX();
+      p0.y = pose0.GetY();
+      edges_marker.points.push_back(p0);
+
+      const auto& pose1 = edge->GetTarget()->GetObject()->GetCorrectedPose();
+      geometry_msgs::msg::Point p1;
+      p1.x = pose1.GetX();
+      p1.y = pose1.GetY();
+      edges_marker.points.push_back(p1);
+  }
+  marray.markers.push_back(edges_marker);
+
   // if disabled, clears out old markers
   interactive_server_->applyChanges();
   marker_publisher_->publish(marray);


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #498 |
| Primary OS tested on | Ubuntu 18.04 |
| Robotic platform tested on | gazebo simulation of small indoor robot with single plane lidar |

---

## Description of contribution in a few bullet points

Add graph edges to graph visualization marker. 

For example:
![image](https://user-images.githubusercontent.com/3259020/174709045-0d952c8c-894a-4d7c-a1f1-2b3ff8f2926c.png)

**Edit:**
I didn't realize this was already implemented for noetic, but looking at it now.  I think this implementation is a bit more simple and efficient.

## Description of documentation updates required from your changes

No documentation updates required.

## Future work that may be required in bullet points

Sequential vs loop closure edges could be distinguished in the future by color.
