### PR TITLE
Clear markers for graph visualization to account for removed nodes.

### DIFF
--- a/src/loop_closure_assistant.cpp
+++ b/src/loop_closure_assistant.cpp
@@ -158,6 +158,13 @@ void LoopClosureAssistant::publishGraph()
   }
 
   visualization_msgs::msg::MarkerArray marray;
+
+  // clear existing markers to account for any removed nodes
+  visualization_msgs::msg::Marker clear;
+  clear.header.stamp = node_->now();
+  clear.action = visualization_msgs::msg::Marker::DELETEALL;
+  marray.markers.push_back(clear);
+
   visualization_msgs::msg::Marker m = vis_utils::toMarker(map_frame_,
       "slam_toolbox", 0.1, node_);
 


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | NA |
| Primary OS tested on | Ubuntu 18.04 |
| Robotic platform tested on | gazebo simulation of small indoor robot with single plane lidar |

---

## Description of contribution in a few bullet points

When removing nodes from the graph, as in the experimental lifetime mode, rviz will keep displaying the removed nodes until the display is toggled because it's not getting any updates telling it to remove the node from the visualization.

The change adds a DELETE_ALL maker to the front of the marker array message to clear any existing markers, which resolves the issue.

## Description of documentation updates required from your changes

No documentation updates required.

---

## Future work that may be required in bullet points

NA
