### PR TITLE
Publish PoseWithCovarianceStamped message with each scan match.

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,8 +174,10 @@ The following are the services/topics that are exposed for use. See the rviz plu
 
 ## Published topics
 
-| map  | `nav_msgs/OccupancyGrid` | occupancy grid representation of the pose-graph at `map_update_interval` frequency | 
+| Topic  | Type | Description | 
 |-----|----|----|
+| map  | `nav_msgs/OccupancyGrid` | occupancy grid representation of the pose-graph at `map_update_interval` frequency | 
+| pose | `geometry_msgs/PoseWithCovarianceStamped` | pose of the base_frame in the configured map_frame along with the covariance calculated from the scan match |
 
 ## Exposed Services
 
@@ -235,6 +237,10 @@ The following settings and options are exposed to you. My default configuration 
 `map_update_interval` - Interval to update the 2D occupancy map for other applications / visualization
 
 `enable_interactive_mode` - Whether or not to allow for interactive mode to be enabled. Interactive mode will retain a cache of laser scans mapped to their ID for visualization in interactive mode. As a result the memory for the process will increase. This is manually disabled in localization and lifelong modes since they would increase the memory utilization over time. Valid for either mapping or continued mapping modes.
+
+`position_covariance_scale` - Amount to scale position covariance when publishing pose from scan match.  Default: 1.0
+
+`yaw_covariance_scale` - Amount to scale yaw covariance when publishing pose from scan match.  Default: 1.0
 
 `resolution` - Resolution of the 2D occupancy map to generate
 

--- a/README.md
+++ b/README.md
@@ -238,9 +238,9 @@ The following settings and options are exposed to you. My default configuration 
 
 `enable_interactive_mode` - Whether or not to allow for interactive mode to be enabled. Interactive mode will retain a cache of laser scans mapped to their ID for visualization in interactive mode. As a result the memory for the process will increase. This is manually disabled in localization and lifelong modes since they would increase the memory utilization over time. Valid for either mapping or continued mapping modes.
 
-`position_covariance_scale` - Amount to scale position covariance when publishing pose from scan match.  Default: 1.0
+`position_covariance_scale` - Amount to scale position covariance when publishing pose from scan match.  This can be used to tune the influence of the pose position in a downstream localization filter.  The covariance represents the uncertainty of the measurement, so scaling up the covariance will result in the pose position having less influence on downstream filters.  Default: 1.0
 
-`yaw_covariance_scale` - Amount to scale yaw covariance when publishing pose from scan match.  Default: 1.0
+`yaw_covariance_scale` - Amount to scale yaw covariance when publishing pose from scan match.  See description of position_covariance_scale.  Default: 1.0
 
 `resolution` - Resolution of the 2D occupancy map to generate
 

--- a/include/slam_toolbox/slam_toolbox_common.hpp
+++ b/include/slam_toolbox/slam_toolbox_common.hpp
@@ -114,6 +114,7 @@ protected:
   bool shouldProcessScan(
     const sensor_msgs::msg::LaserScan::ConstSharedPtr & scan,
     const karto::Pose2 & pose);
+  void publishPose(karto::LocalizedRangeScan * scan, const rclcpp::Time & t);
 
   // pausing bits
   bool isPaused(const PausedApplication & app);
@@ -130,6 +131,7 @@ protected:
   std::unique_ptr<tf2_ros::MessageFilter<sensor_msgs::msg::LaserScan>> scan_filter_;
   std::shared_ptr<rclcpp::Publisher<nav_msgs::msg::OccupancyGrid>> sst_;
   std::shared_ptr<rclcpp::Publisher<nav_msgs::msg::MapMetaData>> sstm_;
+  std::shared_ptr<rclcpp::Publisher<geometry_msgs::msg::PoseWithCovarianceStamped>> pose_pub_;
   std::shared_ptr<rclcpp::Service<nav_msgs::srv::GetMap>> ssMap_;
   std::shared_ptr<rclcpp::Service<slam_toolbox::srv::Pause>> ssPauseMeasurements_;
   std::shared_ptr<rclcpp::Service<slam_toolbox::srv::SerializePoseGraph>> ssSerialize_;
@@ -142,6 +144,8 @@ protected:
   int throttle_scans_;
 
   double resolution_;
+  double position_covariance_scale_;
+  double yaw_covariance_scale_;
   bool first_measurement_, enable_interactive_mode_;
 
   // Book keeping

--- a/include/slam_toolbox/slam_toolbox_common.hpp
+++ b/include/slam_toolbox/slam_toolbox_common.hpp
@@ -114,7 +114,10 @@ protected:
   bool shouldProcessScan(
     const sensor_msgs::msg::LaserScan::ConstSharedPtr & scan,
     const karto::Pose2 & pose);
-  void publishPose(karto::LocalizedRangeScan * scan, const rclcpp::Time & t);
+  void publishPose(
+    const Pose2 & pose,
+    const Matrix3 & cov,
+    const rclcpp::Time & t);
 
   // pausing bits
   bool isPaused(const PausedApplication & app);

--- a/lib/karto_sdk/include/karto_sdk/Karto.h
+++ b/lib/karto_sdk/include/karto_sdk/Karto.h
@@ -5606,6 +5606,16 @@ public:
     m_BoundingBox = bbox;
   }
 
+  inline void SetCovariance(const Matrix3& covariance)
+  {
+    m_Covariance = covariance;
+  }
+
+  inline const Matrix3 GetCovariance() const
+  {
+    return m_Covariance;
+  }
+
   /**
    * Get point readings in local coordinates
    */
@@ -5733,6 +5743,17 @@ private:
    * Corrected pose of robot calculated by mapper (or localizer)
    */
   Pose2 m_CorrectedPose;
+
+  /**
+   * Covariance of corrected pose.
+   *
+   *   | var-x   cov-xy    0    |
+   *   |                        |
+   *   | cov-xy  var-y     0    |
+   *   |                        |
+   *   |  0        0    var-yaw |
+   */
+  Matrix3 m_Covariance;
 
 protected:
   /**

--- a/lib/karto_sdk/include/karto_sdk/Karto.h
+++ b/lib/karto_sdk/include/karto_sdk/Karto.h
@@ -5606,16 +5606,6 @@ public:
     m_BoundingBox = bbox;
   }
 
-  inline void SetCovariance(const Matrix3& covariance)
-  {
-    m_Covariance = covariance;
-  }
-
-  inline const Matrix3 GetCovariance() const
-  {
-    return m_Covariance;
-  }
-
   /**
    * Get point readings in local coordinates
    */
@@ -5743,17 +5733,6 @@ private:
    * Corrected pose of robot calculated by mapper (or localizer)
    */
   Pose2 m_CorrectedPose;
-
-  /**
-   * Covariance of corrected pose.
-   *
-   *   | var-x   cov-xy    0    |
-   *   |                        |
-   *   | cov-xy  var-y     0    |
-   *   |                        |
-   *   |  0        0    var-yaw |
-   */
-  Matrix3 m_Covariance;
 
 protected:
   /**

--- a/lib/karto_sdk/include/karto_sdk/Mapper.h
+++ b/lib/karto_sdk/include/karto_sdk/Mapper.h
@@ -1996,7 +1996,7 @@ public:
    *
    * @return true if the scan was added successfully, false otherwise
    */
-  virtual kt_bool Process(LocalizedRangeScan * pScan, Matrix3* covariance=nullptr);
+  virtual kt_bool Process(LocalizedRangeScan * pScan, Matrix3 * covariance = nullptr);
 
   /**
    * Process an Object
@@ -2004,9 +2004,9 @@ public:
   virtual kt_bool Process(Object * pObject);
 
   // processors
-  kt_bool ProcessAtDock(LocalizedRangeScan * pScan, Matrix3* covariance=nullptr);
-  kt_bool ProcessAgainstNode(LocalizedRangeScan * pScan, const int & nodeId, Matrix3* covariance=nullptr);
-  kt_bool ProcessAgainstNodesNearBy(LocalizedRangeScan * pScan, kt_bool addScanToLocalizationBuffer = false, Matrix3* covariance=nullptr);
+  kt_bool ProcessAtDock(LocalizedRangeScan * pScan, Matrix3 * covariance = nullptr);
+  kt_bool ProcessAgainstNode(LocalizedRangeScan * pScan, const int & nodeId, Matrix3 * covariance = nullptr);
+  kt_bool ProcessAgainstNodesNearBy(LocalizedRangeScan * pScan, kt_bool addScanToLocalizationBuffer = false, Matrix3 * covariance = nullptr);
   kt_bool ProcessLocalization(LocalizedRangeScan * pScan);
   kt_bool RemoveNodeFromGraph(Vertex<LocalizedRangeScan> *);
   void AddScanToLocalizationBuffer(LocalizedRangeScan * pScan, Vertex<LocalizedRangeScan> * scan_vertex);

--- a/lib/karto_sdk/include/karto_sdk/Mapper.h
+++ b/lib/karto_sdk/include/karto_sdk/Mapper.h
@@ -1996,7 +1996,7 @@ public:
    *
    * @return true if the scan was added successfully, false otherwise
    */
-  virtual kt_bool Process(LocalizedRangeScan * pScan);
+  virtual kt_bool Process(LocalizedRangeScan * pScan, Matrix3* covariance=nullptr);
 
   /**
    * Process an Object
@@ -2004,9 +2004,9 @@ public:
   virtual kt_bool Process(Object * pObject);
 
   // processors
-  kt_bool ProcessAtDock(LocalizedRangeScan * pScan);
-  kt_bool ProcessAgainstNode(LocalizedRangeScan * pScan, const int & nodeId);
-  kt_bool ProcessAgainstNodesNearBy(LocalizedRangeScan * pScan, kt_bool addScanToLocalizationBuffer = false);
+  kt_bool ProcessAtDock(LocalizedRangeScan * pScan, Matrix3* covariance=nullptr);
+  kt_bool ProcessAgainstNode(LocalizedRangeScan * pScan, const int & nodeId, Matrix3* covariance=nullptr);
+  kt_bool ProcessAgainstNodesNearBy(LocalizedRangeScan * pScan, kt_bool addScanToLocalizationBuffer = false, Matrix3* covariance=nullptr);
   kt_bool ProcessLocalization(LocalizedRangeScan * pScan);
   kt_bool RemoveNodeFromGraph(Vertex<LocalizedRangeScan> *);
   void AddScanToLocalizationBuffer(LocalizedRangeScan * pScan, Vertex<LocalizedRangeScan> * scan_vertex);

--- a/lib/karto_sdk/src/Mapper.cpp
+++ b/lib/karto_sdk/src/Mapper.cpp
@@ -2676,7 +2676,7 @@ kt_bool Mapper::Process(Object *  /*pObject*/)  // NOLINT
   return true;
 }
 
-kt_bool Mapper::Process(LocalizedRangeScan * pScan)
+kt_bool Mapper::Process(LocalizedRangeScan * pScan, Matrix3 * covariance)
 {
   if (pScan != NULL) {
     karto::LaserRangeFinder * pLaserRangeFinder = pScan->GetLaserRangeFinder();
@@ -2705,8 +2705,8 @@ kt_bool Mapper::Process(LocalizedRangeScan * pScan)
       return false;
     }
 
-    Matrix3 covariance;
-    covariance.SetToIdentity();
+    Matrix3 cov;
+    cov.SetToIdentity();
 
     // correct scan (if not first scan)
     if (m_pUseScanMatching->GetValue() && pLastScan != NULL) {
@@ -2714,9 +2714,11 @@ kt_bool Mapper::Process(LocalizedRangeScan * pScan)
       m_pSequentialScanMatcher->MatchScan(pScan,
         m_pMapperSensorManager->GetRunningScans(pScan->GetSensorName()),
         bestPose,
-        covariance);
+        cov);
       pScan->SetSensorPose(bestPose);
-      pScan->SetCovariance(covariance);
+      if (covariance) {
+        *covariance = cov;
+      }
     }
 
     // add scan to buffer and assign id
@@ -2725,7 +2727,7 @@ kt_bool Mapper::Process(LocalizedRangeScan * pScan)
     if (m_pUseScanMatching->GetValue()) {
       // add to graph
       m_pGraph->AddVertex(pScan);
-      m_pGraph->AddEdges(pScan, covariance);
+      m_pGraph->AddEdges(pScan, cov);
 
       m_pMapperSensorManager->AddRunningScan(pScan);
 
@@ -2746,7 +2748,7 @@ kt_bool Mapper::Process(LocalizedRangeScan * pScan)
   return false;
 }
 
-kt_bool Mapper::ProcessAgainstNodesNearBy(LocalizedRangeScan * pScan, kt_bool addScanToLocalizationBuffer)
+kt_bool Mapper::ProcessAgainstNodesNearBy(LocalizedRangeScan * pScan, kt_bool addScanToLocalizationBuffer, Matrix3* covariance)
 {
   if (pScan != NULL) {
     karto::LaserRangeFinder * pLaserRangeFinder = pScan->GetLaserRangeFinder();
@@ -2774,8 +2776,8 @@ kt_bool Mapper::ProcessAgainstNodesNearBy(LocalizedRangeScan * pScan, kt_bool ad
       m_pMapperSensorManager->SetLastScan(pLastScan);
     }
 
-    Matrix3 covariance;
-    covariance.SetToIdentity();
+    Matrix3 cov;
+    cov.SetToIdentity();
 
     // correct scan (if not first scan)
     if (m_pUseScanMatching->GetValue() && pLastScan != NULL) {
@@ -2783,11 +2785,15 @@ kt_bool Mapper::ProcessAgainstNodesNearBy(LocalizedRangeScan * pScan, kt_bool ad
       m_pSequentialScanMatcher->MatchScan(pScan,
         m_pMapperSensorManager->GetRunningScans(pScan->GetSensorName()),
         bestPose,
-        covariance);
+        cov);
       pScan->SetSensorPose(bestPose);
     }
 
     pScan->SetOdometricPose(pScan->GetCorrectedPose());
+
+    if (covariance) {
+      *covariance = cov;
+    }
 
     // add scan to buffer and assign id
     m_pMapperSensorManager->AddScan(pScan);
@@ -2796,7 +2802,7 @@ kt_bool Mapper::ProcessAgainstNodesNearBy(LocalizedRangeScan * pScan, kt_bool ad
     if (m_pUseScanMatching->GetValue()) {
       // add to graph
       scan_vertex = m_pGraph->AddVertex(pScan);
-      m_pGraph->AddEdges(pScan, covariance);
+      m_pGraph->AddEdges(pScan, cov);
 
       m_pMapperSensorManager->AddRunningScan(pScan);
 
@@ -3013,7 +3019,8 @@ kt_bool Mapper::RemoveNodeFromGraph(Vertex<LocalizedRangeScan> * vertex_to_remov
 
 kt_bool Mapper::ProcessAgainstNode(
   LocalizedRangeScan * pScan,
-  const int & nodeId)
+  const int & nodeId,
+  Matrix3* covariance)
 {
   if (pScan != NULL) {
     karto::LaserRangeFinder * pLaserRangeFinder = pScan->GetLaserRangeFinder();
@@ -3039,8 +3046,8 @@ kt_bool Mapper::ProcessAgainstNode(
     m_pMapperSensorManager->AddRunningScan(pLastScan);
     m_pMapperSensorManager->SetLastScan(pLastScan);
 
-    Matrix3 covariance;
-    covariance.SetToIdentity();
+    Matrix3 cov;
+    cov.SetToIdentity();
 
     // correct scan (if not first scan)
     if (m_pUseScanMatching->GetValue() && pLastScan != NULL) {
@@ -3048,11 +3055,14 @@ kt_bool Mapper::ProcessAgainstNode(
       m_pSequentialScanMatcher->MatchScan(pScan,
         m_pMapperSensorManager->GetRunningScans(pScan->GetSensorName()),
         bestPose,
-        covariance);
+        cov);
       pScan->SetSensorPose(bestPose);
     }
 
     pScan->SetOdometricPose(pScan->GetCorrectedPose());
+    if (covariance) {
+      *covariance = cov;
+    }
 
     // add scan to buffer and assign id
     m_pMapperSensorManager->AddScan(pScan);
@@ -3060,7 +3070,7 @@ kt_bool Mapper::ProcessAgainstNode(
     if (m_pUseScanMatching->GetValue()) {
       // add to graph
       m_pGraph->AddVertex(pScan);
-      m_pGraph->AddEdges(pScan, covariance);
+      m_pGraph->AddEdges(pScan, cov);
 
       m_pMapperSensorManager->AddRunningScan(pScan);
 
@@ -3082,10 +3092,10 @@ kt_bool Mapper::ProcessAgainstNode(
   return false;
 }
 
-kt_bool Mapper::ProcessAtDock(LocalizedRangeScan * pScan)
+kt_bool Mapper::ProcessAtDock(LocalizedRangeScan * pScan, Matrix3* covariance)
 {
   // Special case of processing against node where node is the starting point
-  return ProcessAgainstNode(pScan, 0);
+  return ProcessAgainstNode(pScan, 0, covariance);
 }
 
 /**

--- a/lib/karto_sdk/src/Mapper.cpp
+++ b/lib/karto_sdk/src/Mapper.cpp
@@ -2716,6 +2716,7 @@ kt_bool Mapper::Process(LocalizedRangeScan * pScan)
         bestPose,
         covariance);
       pScan->SetSensorPose(bestPose);
+      pScan->SetCovariance(covariance);
     }
 
     // add scan to buffer and assign id

--- a/lib/karto_sdk/src/Mapper.cpp
+++ b/lib/karto_sdk/src/Mapper.cpp
@@ -2748,7 +2748,7 @@ kt_bool Mapper::Process(LocalizedRangeScan * pScan, Matrix3 * covariance)
   return false;
 }
 
-kt_bool Mapper::ProcessAgainstNodesNearBy(LocalizedRangeScan * pScan, kt_bool addScanToLocalizationBuffer, Matrix3* covariance)
+kt_bool Mapper::ProcessAgainstNodesNearBy(LocalizedRangeScan * pScan, kt_bool addScanToLocalizationBuffer, Matrix3 * covariance)
 {
   if (pScan != NULL) {
     karto::LaserRangeFinder * pLaserRangeFinder = pScan->GetLaserRangeFinder();
@@ -3020,7 +3020,7 @@ kt_bool Mapper::RemoveNodeFromGraph(Vertex<LocalizedRangeScan> * vertex_to_remov
 kt_bool Mapper::ProcessAgainstNode(
   LocalizedRangeScan * pScan,
   const int & nodeId,
-  Matrix3* covariance)
+  Matrix3 * covariance)
 {
   if (pScan != NULL) {
     karto::LaserRangeFinder * pLaserRangeFinder = pScan->GetLaserRangeFinder();
@@ -3092,7 +3092,7 @@ kt_bool Mapper::ProcessAgainstNode(
   return false;
 }
 
-kt_bool Mapper::ProcessAtDock(LocalizedRangeScan * pScan, Matrix3* covariance)
+kt_bool Mapper::ProcessAtDock(LocalizedRangeScan * pScan, Matrix3 * covariance)
 {
   // Special case of processing against node where node is the starting point
   return ProcessAgainstNode(pScan, 0, covariance);


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #481, #427  |
| Primary OS tested on | Ubuntu 18.04 |
| Robotic platform tested on | gazebo simulation of small indoor robot with single plane lidar |

---

## Description of contribution in a few bullet points

Publish a PoseWithCovarianceStamped message with each scan match so that slam_toolbox can be more easily integrated with a downstream filter such as robot_localization.

 - Adds publisher on `pose` topic
 - Fills in pose and covariance from scan match result
 - Adds parameters to scale the covariance before publishing
     - `position_covariance_scale`
     - `yaw_covariance_scale`

Example results:
![image](https://user-images.githubusercontent.com/3259020/174705993-f4df1f17-fb0a-4c46-b028-9a62e9662b3f.png)

![image](https://user-images.githubusercontent.com/3259020/174706056-c710199a-a226-4b6b-a8e4-feae7303db7c.png)

![image](https://user-images.githubusercontent.com/3259020/174706113-4152b87e-bb53-499a-9b43-c778c787302d.png)


## Description of documentation updates required from your changes

README updated

---

## Future work that may be required in bullet points

