### PR TITLE
Stop ceres problem from freeing loss function

### DIFF
--- a/solvers/ceres_solver.cpp
+++ b/solvers/ceres_solver.cpp
@@ -145,6 +145,10 @@ void CeresSolver::Configure(rclcpp::Node::SharedPtr node)
     options_problem_.enable_fast_removal = true;
   }
 
+  // we do not want the problem definition to own these objects, otherwise they get
+  // deleted along with the problem 
+  options_problem_.loss_function_ownership = ceres::Ownership::DO_NOT_TAKE_OWNERSHIP;
+
   problem_ = new ceres::Problem(options_problem_);
 }
 
@@ -157,6 +161,9 @@ CeresSolver::~CeresSolver()
   }
   if (nodes_ != NULL) {
     delete nodes_;
+  }
+  if (blocks_ != NULL) {
+    delete blocks_;
   }
   if (problem_ != NULL) {
     delete problem_;
@@ -242,6 +249,8 @@ void CeresSolver::Reset()
   was_constant_set_ = false;
 
   if (problem_) {
+    // Note that this also frees anything the problem owns (i.e. local parameterization, cost
+    // function)
     delete problem_;
   }
 


### PR DESCRIPTION
---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | N/A |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | gazebo simulation |

---

## Description of contribution in a few bullet points

* Stop ceres problem from freeing the loss function when we reset the solver. This is important because otherwise calling solver_->Reset() invalidates the loss_function_ pointer held by the solver_ (whereas I would expect the behavior of solver_->Reset() to be that the loss function is left unchanged). Open to alternative ways to address this problem, but this worked for my use case. 
* It also seemed like the blocks_ object should be freed in the ~CeresSolver() function (since I don't think the problem takes ownership of this).
* I ran into this issue because in my use case, I need to cleanly reset the slam toolbox state multiple times without killing the process (funny enough you don't run into major issues until the second time you call solver_->Reset()). I also think this would affect people if they needed to call deserialize pose graph multiple times.

## Description of documentation updates required from your changes

None that I know of.

---

## Future work that may be required in bullet points

* I hope to make a future PR with the reset function if it makes sense for general use cases. atm it seems unique to my use case.
