### PR TITLE
Midigate spamming for 50Hz lidar

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,8 @@ The following settings and options are exposed to you. My default configuration 
 
 `scan_topic` - scan topic, *absolute* path, ei `/scan` not `scan`
 
+`scan_queue_size` - The number of scan messages to queue up before throwing away old ones. Should always be set to 1 in async mode
+
 `map_file_name` - Name of the pose-graph file to load on startup if available
 
 `map_start_pose` - Pose to start pose-graph mapping/localization in, if available

--- a/include/slam_toolbox/slam_toolbox_common.hpp
+++ b/include/slam_toolbox/slam_toolbox_common.hpp
@@ -144,7 +144,7 @@ protected:
   std::string odom_frame_, map_frame_, base_frame_, map_name_, scan_topic_;
   rclcpp::Duration transform_timeout_, minimum_time_interval_;
   std_msgs::msg::Header scan_header;
-  int throttle_scans_;
+  int throttle_scans_, scan_queue_size_;
 
   double resolution_;
   double position_covariance_scale_;

--- a/src/slam_toolbox_common.cpp
+++ b/src/slam_toolbox_common.cpp
@@ -217,7 +217,7 @@ void SlamToolbox::setROSInterfaces()
     shared_from_this().get(), scan_topic_, rmw_qos_profile_sensor_data);
   scan_filter_ =
     std::make_unique<tf2_ros::MessageFilter<sensor_msgs::msg::LaserScan>>(
-    *scan_filter_sub_, *tf_, odom_frame_, 1, shared_from_this(),
+    *scan_filter_sub_, *tf_, odom_frame_, 5, shared_from_this(),
     tf2::durationFromSec(transform_timeout_.seconds()));
   scan_filter_->registerCallback(
     std::bind(&SlamToolbox::laserCallback, this, std::placeholders::_1));

--- a/src/slam_toolbox_common.cpp
+++ b/src/slam_toolbox_common.cpp
@@ -142,6 +142,9 @@ void SlamToolbox::setParams()
   scan_topic_ = std::string("/scan");
   scan_topic_ = this->declare_parameter("scan_topic", scan_topic_);
 
+  scan_queue_size_ = 1.0;
+  scan_queue_size_ = this->declare_parameter("scan_queue_size", scan_queue_size_);
+
   throttle_scans_ = 1;
   throttle_scans_ = this->declare_parameter("throttle_scans", throttle_scans_);
 
@@ -217,7 +220,7 @@ void SlamToolbox::setROSInterfaces()
     shared_from_this().get(), scan_topic_, rmw_qos_profile_sensor_data);
   scan_filter_ =
     std::make_unique<tf2_ros::MessageFilter<sensor_msgs::msg::LaserScan>>(
-    *scan_filter_sub_, *tf_, odom_frame_, 5, shared_from_this(),
+    *scan_filter_sub_, *tf_, odom_frame_, scan_queue_size_, shared_from_this(),
     tf2::durationFromSec(transform_timeout_.seconds()));
   scan_filter_->registerCallback(
     std::bind(&SlamToolbox::laserCallback, this, std::placeholders::_1));


### PR DESCRIPTION
## Basic Info

I'm trying to use Slam Toolbox on a Clearpath Husky with lms111 lidars that default to 50Hz.

Currently, I get a massive amount of info messages about dropped messages in the terminal
```bash
[sync_slam_toolbox_node-15] [INFO] [1661266264.459040162] [slam_toolbox]: Message Filter dropping message: frame 'base_link' at time 5.393 for reason 'discarding message because the queue is full'
[sync_slam_toolbox_node-15] [INFO] [1661266264.499800792] [slam_toolbox]: Message Filter dropping message: frame 'base_link' at time 5.433 for reason 'discarding message because the queue is full'
[sync_slam_toolbox_node-15] [INFO] [1661266264.519281786] [slam_toolbox]: Message Filter dropping message: frame 'base_link' at time 5.453 for reason 'discarding message because the queue is full'
[sync_slam_toolbox_node-15] [INFO] [1661266264.539066862] [slam_toolbox]: Message Filter dropping message: frame 'base_link' at time 5.473 for reason 'discarding message because the queue is full'
[sync_slam_toolbox_node-15] [INFO] [1661266264.559734918] [slam_toolbox]: Message Filter dropping message: frame 'base_link' at time 5.493 for reason 'discarding message because the queue is full'
[sync_slam_toolbox_node-15] [INFO] [1661266264.598413246] [slam_toolbox]: Message Filter dropping message: frame 'base_link' at time 5.534 for reason 'discarding message because the queue is full'
[sync_slam_toolbox_node-15] [INFO] [1661266264.618225423] [slam_toolbox]: Message Filter dropping message: frame 'base_link' at time 5.553 for reason 'discarding message because the queue is full'
[sync_slam_toolbox_node-15] [INFO] [1661266264.638513284] [slam_toolbox]: Message Filter dropping message: frame 'base_link' at time 5.573 for reason 'discarding message because the queue is full'
```
Increasing the queue_size a bit seems to mitigate most of the problem, but maybe there is a better solution.

| ------ | ----------- |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | gazebo simulation, Clearpath Husky |

---

## Description of contribution in a few bullet points

* Increased queue_size for scan_filter

