### PR TITLE
Fix segfault after loading posegraph

### DIFF
--- a/include/slam_toolbox/loop_closure_assistant.hpp
+++ b/include/slam_toolbox/loop_closure_assistant.hpp
@@ -53,6 +53,7 @@ public:
   void processInteractiveFeedback(
     const visualization_msgs::msg::InteractiveMarkerFeedback::ConstSharedPtr feedback);
   void publishGraph();
+  void setMapper(karto::Mapper * mapper);
 
 private:
   bool manualLoopClosureCallback(

--- a/src/loop_closure_assistant.cpp
+++ b/src/loop_closure_assistant.cpp
@@ -72,6 +72,14 @@ LoopClosureAssistant::LoopClosureAssistant(
 }
 
 /*****************************************************************************/
+void LoopClosureAssistant::setMapper(karto::Mapper * mapper)
+/*****************************************************************************/
+{
+  mapper_ = mapper;
+}
+
+
+/*****************************************************************************/
 void LoopClosureAssistant::processInteractiveFeedback(const
   visualization_msgs::msg::InteractiveMarkerFeedback::ConstSharedPtr feedback)
 /*****************************************************************************/

--- a/src/loop_closure_assistant.cpp
+++ b/src/loop_closure_assistant.cpp
@@ -78,7 +78,6 @@ void LoopClosureAssistant::setMapper(karto::Mapper * mapper)
   mapper_ = mapper;
 }
 
-
 /*****************************************************************************/
 void LoopClosureAssistant::processInteractiveFeedback(const
   visualization_msgs::msg::InteractiveMarkerFeedback::ConstSharedPtr feedback)
@@ -145,7 +144,6 @@ void LoopClosureAssistant::processInteractiveFeedback(const
     scan_publisher_->publish(scan);
   }
 }
-
 
 /*****************************************************************************/
 void LoopClosureAssistant::publishGraph()

--- a/src/slam_toolbox_common.cpp
+++ b/src/slam_toolbox_common.cpp
@@ -728,6 +728,8 @@ void SlamToolbox::loadSerializedPoseGraph(
   smapper_->configure(shared_from_this());
   dataset_.reset(dataset.release());
 
+  closure_assistant_->setMapper(smapper_->getMapper());
+
   if (!smapper_->getMapper()) {
     RCLCPP_FATAL(get_logger(),
       "loadSerializedPoseGraph: Could not properly load "


### PR DESCRIPTION
## Basic Info
I was getting a segfault in in `localization_slam_toolbox_node` after loading a posegraph from a file here in the code: https://github.com/SteveMacenski/slam_toolbox/blob/ae68b851094668738fd32e8dc6e72e18fd15a965/src/loop_closure_assistant.cpp#L189

The problem is that the `LoopClosureAssistant` was created with a raw pointer to a `karto::Mapper` instance from a unique pointer. The raw pointer is not replaced when a new serialized pose graph is loaded. Trying to call functions on the `mapper_` pointer in the `LoopClosureAssistant` after that will cause a segfault.

| Primary OS tested on | Ubuntu |
| Robotic platform tested on | gazebo simulation of Husky |

---

## Description of contribution in a few bullet points

* Added a setter for the `mapper_` pointer to `LoopClosureAssistant`
* Updated the mapper used by `LoopClosureAssistant` in `loadSerializedPoseGraph`

## Future work that may be required

It seems a bit strange to me that `LoopClosureAssistant` is using raw pointers rather that smart pointers. I suspect there is a reason for this thought... If not, it not we should probably change it so it uses smart pointers and avoid segfaults like this.
