### PR TITLE
Protect graph from parallel access during visualization.

### DIFF
--- a/src/slam_toolbox_common.cpp
+++ b/src/slam_toolbox_common.cpp
@@ -273,6 +273,7 @@ void SlamToolbox::publishVisualizations()
   while (rclcpp::ok()) {
     updateMap();
     if (!isPaused(VISUALIZING_GRAPH)) {
+      boost::mutex::scoped_lock lock(smapper_mutex_);
       closure_assistant_->publishGraph();
     }
     r.sleep();


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #497 |
| Primary OS tested on | Ubuntu 20.04 |
| Robotic platform tested on | (Steve's Robot, gazebo simulation of Tally, hardware turtlebot) |

## Description of contribution in a few bullet points

* Protect graph from parallel access during visualization.

@SteveMacenski I'm not sure if this fixes the issue or not, but it seems likely that a mutex is required here.

I can test this later today or tomorrow.