### PR TITLE
Fix segfault in LoopClosureAssistant when loading a map.

### DIFF
--- a/slam_toolbox/include/slam_toolbox/loop_closure_assistant.hpp
+++ b/slam_toolbox/include/slam_toolbox/loop_closure_assistant.hpp
@@ -47,6 +47,7 @@ public:
   void clearMovedNodes();
   void processInteractiveFeedback(const visualization_msgs::InteractiveMarkerFeedbackConstPtr& feedback);
   void publishGraph();
+  void setMapper(karto::Mapper * mapper);
 
 private:
   bool manualLoopClosureCallback(slam_toolbox_msgs::LoopClosure::Request& req, slam_toolbox_msgs::LoopClosure::Response& resp);

--- a/slam_toolbox/src/loop_closure_assistant.cpp
+++ b/slam_toolbox/src/loop_closure_assistant.cpp
@@ -54,6 +54,13 @@ LoopClosureAssistant::LoopClosureAssistant(
 }
 
 /*****************************************************************************/
+void LoopClosureAssistant::setMapper(karto::Mapper * mapper)
+/*****************************************************************************/
+{
+  mapper_ = mapper;
+}
+
+/*****************************************************************************/
 void LoopClosureAssistant::processInteractiveFeedback(const
   visualization_msgs::InteractiveMarkerFeedbackConstPtr& feedback)
 /*****************************************************************************/

--- a/slam_toolbox/src/slam_toolbox_common.cpp
+++ b/slam_toolbox/src/slam_toolbox_common.cpp
@@ -640,6 +640,8 @@ void SlamToolbox::loadSerializedPoseGraph(
   smapper_->configure(nh_);
   dataset_.reset(dataset.release());
 
+  closure_assistant_->setMapper(smapper_->getMapper());
+
   if (!smapper_->getMapper())
   {
     ROS_FATAL("loadSerializedPoseGraph: Could not properly load "


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #497 |
| Primary OS tested on | Ubuntu 20.04 |
| Robotic platform tested on | gazebo sim |

---

## Description of contribution in a few bullet points

Fix segfault in LoopClosureAssistant when loading a map.

The noetic branch was missing this code, which is present in the ros2 version.
