### PR TITLE
Fixed constraint between first scans for multilaser systems

### DIFF
--- a/lib/karto_sdk/src/Mapper.cpp
+++ b/lib/karto_sdk/src/Mapper.cpp
@@ -1473,7 +1473,7 @@ void MapperGraph::AddEdges(LocalizedRangeScan * pScan, const Matrix3 & rCovarian
         pScan,
         pSensorManager->GetScans(rCandidateSensorName),
         bestPose, covariance);
-      LinkScans(pScan, pSensorManager->GetScan(rCandidateSensorName, 0), bestPose, covariance);
+      LinkScans(pSensorManager->GetScan(rCandidateSensorName, 0), pScan, bestPose, covariance);
 
       // only add to means and covariances if response was high "enough"
       if (response > m_pMapper->m_pLinkMatchMinimumResponseFine->GetValue()) {


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | none |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Gazebo sim |

Before and after fix:
[mr_slam_prototype_loop_closure.webm](https://user-images.githubusercontent.com/89307447/193109366-70cec3fa-717a-46f7-b6a9-4c6a9efc8cb5.webm)
[mr_slam_prototype_loop_closure_fixed.webm](https://user-images.githubusercontent.com/89307447/193109379-28bf77ca-e04e-4b8e-aa66-93269e617cb7.webm)
Robots start 0.5 m apart. Before fix, when loop closure occurs the two first nodes are moved to the same place (incorrectly), resulting in certain walls showing up twice. This is most apparent with the south wall, where there is the original wall, then a copy of the original wall, 0.5 meters apart. After the fix, when loop closure occurs, the two first nodes have correct constraints between them, which results in the map not being distorted, and the walls showing up multiple times.


---
## Description of contribution in a few bullet points
Fixed constraint calculation between first scans for systems with multiple laser sensors

## Description of documentation updates required from your changes
None

---

## Future work that may be required in bullet points
None
