### PR TITLE
Multi-robot SLAM

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,17 @@ The video below was collected at [Circuit Launch](https://www.circuitlaunch.com/
 
 ![map_image](/images/circuit_launch.gif?raw=true "Map Image")
 
+# Multi-Robot SLAM
+SLAM Toolbox supports multi-robot SLAM. The robots must all start in the same location, facing the same way. The first robot to connect determines the world origin, and the relative starting points of the other robots are determined using laser scan matching. This allows all robots to add to a shared pose graph, which makes possible:
+- Localization of multiple robots
+- Mapping using information from all sensor readings
+- Loop closures across robots
+
+Currently, synchornous and asynchornous mapping is supported.
+
+![MRSLAM_gif](/images/mrslam_readme.gif?raw=true "Multi-Robot SLAM")
+
+`odom_frames`, `base_frames`, and `laser_topics` define odom frame, base frame, and laser topic for all robots. These params must all have the same order of robots, and must have the same number of elements. This means that each robot can only have one LIDAR.
 
 # 03/23/2021 Note On Serialized Files
 

--- a/slam_toolbox/config/mapper_params_online_async.yaml
+++ b/slam_toolbox/config/mapper_params_online_async.yaml
@@ -7,17 +7,17 @@ ceres_dogleg_type: TRADITIONAL_DOGLEG
 ceres_loss_function: None
 
 # ROS Parameters
-odom_frame: odom
 map_frame: map
-base_frame: base_footprint
-scan_topic: /scan
+odom_frames: ["robot1/odom", "robot2/odom"]
+base_frames: ["robot1/base_footprint", "robot2/base_footprint"]
+laser_topics: ["/robot1/scan", "/robot2/scan"]
 mode: mapping #localization
 
 # if you'd like to immediately start continuing a map at a given pose
 # or at the dock, but they are mutually exclusive, if pose is given
 # will use pose
 #map_file_name: test_steve
-# map_start_pose: [0.0, 0.0, 0.0]
+#map_start_pose: [0.0, 0.0, 0.0]
 #map_start_at_dock: true
 
 debug_logging: false

--- a/slam_toolbox/config/mapper_params_online_sync.yaml
+++ b/slam_toolbox/config/mapper_params_online_sync.yaml
@@ -10,7 +10,7 @@ ceres_loss_function: None
 odom_frame: odom
 map_frame: map
 base_frame: base_footprint
-scan_topic: /scan
+laser_topics: ["/scan"]
 mode: mapping #localization
 
 # if you'd like to immediately start continuing a map at a given pose

--- a/slam_toolbox/config/mapper_params_online_sync.yaml
+++ b/slam_toolbox/config/mapper_params_online_sync.yaml
@@ -7,10 +7,10 @@ ceres_dogleg_type: TRADITIONAL_DOGLEG
 ceres_loss_function: None
 
 # ROS Parameters
-odom_frame: odom
 map_frame: map
-base_frame: base_footprint
-laser_topics: ["/scan"]
+odom_frames: ["robot1/odom", "robot2/odom"]
+base_frames: ["robot1/base_footprint", "robot2/base_footprint"]
+laser_topics: ["robot1/scan, robot2/scan"]
 mode: mapping #localization
 
 # if you'd like to immediately start continuing a map at a given pose

--- a/slam_toolbox/config/mapper_params_online_sync.yaml
+++ b/slam_toolbox/config/mapper_params_online_sync.yaml
@@ -10,7 +10,7 @@ ceres_loss_function: None
 map_frame: map
 odom_frames: ["robot1/odom", "robot2/odom"]
 base_frames: ["robot1/base_footprint", "robot2/base_footprint"]
-laser_topics: ["robot1/scan, robot2/scan"]
+laser_topics: ["/robot1/scan", "/robot2/scan"]
 mode: mapping #localization
 
 # if you'd like to immediately start continuing a map at a given pose

--- a/slam_toolbox/include/slam_toolbox/experimental/slam_toolbox_lifelong.hpp
+++ b/slam_toolbox/include/slam_toolbox/experimental/slam_toolbox_lifelong.hpp
@@ -42,7 +42,7 @@ public:
 
 protected:
   virtual void laserCallback(
-    const sensor_msgs::LaserScan::ConstPtr& scan) override final;
+    const sensor_msgs::LaserScan::ConstPtr& scan, const std::string& base_frame_id) override final;
   virtual bool deserializePoseGraphCallback(
     slam_toolbox_msgs::DeserializePoseGraph::Request& req,
     slam_toolbox_msgs::DeserializePoseGraph::Response& resp) override final;

--- a/slam_toolbox/include/slam_toolbox/get_pose_helper.hpp
+++ b/slam_toolbox/include/slam_toolbox/get_pose_helper.hpp
@@ -37,8 +37,15 @@ public:
   {
   };
 
-  bool getOdomPose(karto::Pose2& karto_pose, const ros::Time& t)
+  bool getOdomPose(karto::Pose2& karto_pose,
+    const ros::Time& t,
+    std::string ref_frame = std::string(""))
   {
+    // Only succeed if ref_frame matches base_frame_; otherwise using wrong pose helper
+    if(ref_frame != base_frame_)
+    {
+      return false;
+    }
     geometry_msgs::TransformStamped base_ident, odom_pose;
     base_ident.header.stamp = t;
     base_ident.header.frame_id = base_frame_;

--- a/slam_toolbox/include/slam_toolbox/get_pose_helper.hpp
+++ b/slam_toolbox/include/slam_toolbox/get_pose_helper.hpp
@@ -37,9 +37,7 @@ public:
   {
   };
 
-  bool getOdomPose(karto::Pose2& karto_pose,
-    const ros::Time& t,
-    std::string ref_frame = std::string(""))
+  bool getOdomPose(karto::Pose2& karto_pose, const ros::Time& t, std::string ref_frame)
   {
     // Only succeed if ref_frame matches base_frame_; otherwise using wrong pose helper
     if(ref_frame != base_frame_)

--- a/slam_toolbox/include/slam_toolbox/loop_closure_assistant.hpp
+++ b/slam_toolbox/include/slam_toolbox/loop_closure_assistant.hpp
@@ -55,6 +55,7 @@ private:
   bool interactiveModeCallback(slam_toolbox_msgs::ToggleInteractive::Request  &req, slam_toolbox_msgs::ToggleInteractive::Response &resp);
   void moveNode(const int& id, const Eigen::Vector3d& pose);
   void addMovedNodes(const int& id, Eigen::Vector3d vec);
+  std_msgs::ColorRGBA createNewColor();
 
   std::unique_ptr<tf2_ros::TransformBroadcaster> tfB_;
   laser_utils::ScanHolder* scan_holder_;
@@ -72,6 +73,7 @@ private:
   std::string map_frame_;
   PausedState& state_;
   ProcessType& processor_type_;
+  std::map<karto::Name, std_msgs::ColorRGBA> m_sensor_name_to_color_;
 };
 
 }  // end namespace

--- a/slam_toolbox/include/slam_toolbox/slam_toolbox_async.hpp
+++ b/slam_toolbox/include/slam_toolbox/slam_toolbox_async.hpp
@@ -33,7 +33,7 @@ public:
 
 protected:
   virtual void laserCallback(
-    const sensor_msgs::LaserScan::ConstPtr& scan) override final;
+    const sensor_msgs::LaserScan::ConstPtr& scan, const std::string& base_frame_id) override final;
   virtual bool deserializePoseGraphCallback(
     slam_toolbox_msgs::DeserializePoseGraph::Request& req,
     slam_toolbox_msgs::DeserializePoseGraph::Response& resp) override final;

--- a/slam_toolbox/include/slam_toolbox/slam_toolbox_common.hpp
+++ b/slam_toolbox/include/slam_toolbox/slam_toolbox_common.hpp
@@ -87,7 +87,7 @@ protected:
   karto::LocalizedRangeScan* addScan(karto::LaserRangeFinder* laser, PosedScan& scanWPose);
   bool updateMap();
   tf2::Stamped<tf2::Transform> setTransformFromPoses(const karto::Pose2& pose,
-    const karto::Pose2& karto_pose, const ros::Time& t, const bool& update_reprocessing_transform);
+    const karto::Pose2& karto_pose, const std_msgs::Header& header, const bool& update_reprocessing_transform);
   karto::LocalizedRangeScan* getLocalizedRangeScan(karto::LaserRangeFinder* laser,
     const sensor_msgs::LaserScan::ConstPtr& scan,
     karto::Pose2& karto_pose);

--- a/slam_toolbox/include/slam_toolbox/slam_toolbox_common.hpp
+++ b/slam_toolbox/include/slam_toolbox/slam_toolbox_common.hpp
@@ -122,6 +122,7 @@ protected:
   std::unique_ptr<mapper_utils::SMapper> smapper_;
   std::unique_ptr<karto::Dataset> dataset_;
   std::map<std::string, laser_utils::LaserMetadata> lasers_;
+  std::map<std::string, tf2::Transform> m_map_to_odoms_;
 
   // helpers
   std::map<std::string,std::unique_ptr<laser_utils::LaserAssistant>> laser_assistants_;

--- a/slam_toolbox/include/slam_toolbox/slam_toolbox_common.hpp
+++ b/slam_toolbox/include/slam_toolbox/slam_toolbox_common.hpp
@@ -123,6 +123,7 @@ protected:
   std::unique_ptr<karto::Dataset> dataset_;
   std::map<std::string, laser_utils::LaserMetadata> lasers_;
   std::map<std::string, tf2::Transform> m_map_to_odoms_;
+  std::map<std::string, std::string> m_base_id_to_odom_id_;
 
   // helpers
   std::map<std::string,std::unique_ptr<laser_utils::LaserAssistant>> laser_assistants_;

--- a/slam_toolbox/include/slam_toolbox/slam_toolbox_common.hpp
+++ b/slam_toolbox/include/slam_toolbox/slam_toolbox_common.hpp
@@ -103,13 +103,14 @@ protected:
   std::unique_ptr<tf2_ros::Buffer> tf_;
   std::unique_ptr<tf2_ros::TransformListener> tfL_;
   std::unique_ptr<tf2_ros::TransformBroadcaster> tfB_;
-  std::unique_ptr<message_filters::Subscriber<sensor_msgs::LaserScan> > scan_filter_sub_;
-  std::unique_ptr<tf2_ros::MessageFilter<sensor_msgs::LaserScan> > scan_filter_;
+  std::vector<std::unique_ptr<message_filters::Subscriber<sensor_msgs::LaserScan> > > scan_filter_subs_;
+  std::vector<std::unique_ptr<tf2_ros::MessageFilter<sensor_msgs::LaserScan> > > scan_filters_;
   ros::Publisher sst_, sstm_;
   ros::ServiceServer ssMap_, ssPauseMeasurements_, ssSerialize_, ssDesserialize_;
 
   // Storage for ROS parameters
-  std::string odom_frame_, map_frame_, base_frame_, map_name_, scan_topic_;
+  std::string odom_frame_, map_frame_, base_frame_, map_name_;
+  std::vector<std::string> laser_topics_;
   ros::Duration transform_timeout_, tf_buffer_dur_, minimum_time_interval_;
   int throttle_scans_;
 

--- a/slam_toolbox/include/slam_toolbox/slam_toolbox_common.hpp
+++ b/slam_toolbox/include/slam_toolbox/slam_toolbox_common.hpp
@@ -127,7 +127,7 @@ protected:
 
   // helpers
   std::map<std::string,std::unique_ptr<laser_utils::LaserAssistant>> laser_assistants_;
-  std::vector<std::unique_ptr<pose_utils::GetPoseHelper>> pose_helpers_;
+  std::map<std::string,std::unique_ptr<pose_utils::GetPoseHelper>> pose_helpers_;
   std::unique_ptr<map_saver::MapSaver> map_saver_;
   std::unique_ptr<loop_closure_assistant::LoopClosureAssistant> closure_assistant_;
   std::unique_ptr<laser_utils::ScanHolder> scan_holder_;

--- a/slam_toolbox/include/slam_toolbox/slam_toolbox_common.hpp
+++ b/slam_toolbox/include/slam_toolbox/slam_toolbox_common.hpp
@@ -134,8 +134,6 @@ protected:
 
   // Internal state
   std::vector<std::unique_ptr<boost::thread> > threads_;
-  tf2::Transform map_to_odom_;
-  std::string map_to_odom_child_frame_id_;
   boost::mutex map_to_odom_mutex_, smapper_mutex_, pose_mutex_;
   PausedState state_;
   nav_msgs::GetMap::Response map_;

--- a/slam_toolbox/include/slam_toolbox/slam_toolbox_common.hpp
+++ b/slam_toolbox/include/slam_toolbox/slam_toolbox_common.hpp
@@ -70,7 +70,7 @@ protected:
   void setROSInterfaces(ros::NodeHandle& node);
 
   // callbacks
-  virtual void laserCallback(const sensor_msgs::LaserScan::ConstPtr& scan) = 0;
+  virtual void laserCallback(const sensor_msgs::LaserScan::ConstPtr& scan, const std::string& base_frame_id) = 0;
   bool mapCallback(nav_msgs::GetMap::Request& req,
     nav_msgs::GetMap::Response& res);
   virtual bool serializePoseGraphCallback(slam_toolbox_msgs::SerializePoseGraph::Request& req,
@@ -123,7 +123,7 @@ protected:
   std::unique_ptr<karto::Dataset> dataset_;
   std::map<std::string, laser_utils::LaserMetadata> lasers_;
   std::map<std::string, tf2::Transform> m_map_to_odoms_;
-  std::map<std::string, std::string> m_base_id_to_odom_id_;
+  std::map<std::string, std::string> m_base_id_to_odom_id_, m_laser_id_to_base_id_;
 
   // helpers
   std::map<std::string,std::unique_ptr<laser_utils::LaserAssistant>> laser_assistants_;
@@ -134,7 +134,7 @@ protected:
 
   // Internal state
   std::vector<std::unique_ptr<boost::thread> > threads_;
-  boost::mutex map_to_odom_mutex_, smapper_mutex_, pose_mutex_;
+  boost::mutex map_to_odom_mutex_, smapper_mutex_, pose_mutex_, laser_id_map_mutex_;
   PausedState state_;
   nav_msgs::GetMap::Response map_;
   ProcessType processor_type_;

--- a/slam_toolbox/include/slam_toolbox/slam_toolbox_common.hpp
+++ b/slam_toolbox/include/slam_toolbox/slam_toolbox_common.hpp
@@ -124,7 +124,7 @@ protected:
   std::map<std::string, laser_utils::LaserMetadata> lasers_;
 
   // helpers
-  std::unique_ptr<laser_utils::LaserAssistant> laser_assistant_;
+  std::map<std::string,std::unique_ptr<laser_utils::LaserAssistant>> laser_assistants_;
   std::vector<std::unique_ptr<pose_utils::GetPoseHelper>> pose_helpers_;
   std::unique_ptr<map_saver::MapSaver> map_saver_;
   std::unique_ptr<loop_closure_assistant::LoopClosureAssistant> closure_assistant_;

--- a/slam_toolbox/include/slam_toolbox/slam_toolbox_common.hpp
+++ b/slam_toolbox/include/slam_toolbox/slam_toolbox_common.hpp
@@ -110,7 +110,7 @@ protected:
   ros::ServiceServer ssMap_, ssPauseMeasurements_, ssSerialize_, ssDesserialize_;
 
   // Storage for ROS parameters
-  std::string odom_frame_, map_frame_, base_frame_, map_name_;
+  std::string map_frame_, map_name_;
   std::vector<std::string> odom_frames_, base_frames_, laser_topics_;
   ros::Duration transform_timeout_, tf_buffer_dur_, minimum_time_interval_;
   int throttle_scans_;
@@ -133,6 +133,7 @@ protected:
   // Internal state
   std::vector<std::unique_ptr<boost::thread> > threads_;
   tf2::Transform map_to_odom_;
+  std::string map_to_odom_child_frame_id_;
   boost::mutex map_to_odom_mutex_, smapper_mutex_, pose_mutex_;
   PausedState state_;
   nav_msgs::GetMap::Response map_;

--- a/slam_toolbox/include/slam_toolbox/slam_toolbox_common.hpp
+++ b/slam_toolbox/include/slam_toolbox/slam_toolbox_common.hpp
@@ -45,6 +45,7 @@
 #include <fstream>
 #include <boost/thread.hpp>
 #include <sys/resource.h>
+#include <assert.h>
 
 namespace slam_toolbox
 {
@@ -110,7 +111,7 @@ protected:
 
   // Storage for ROS parameters
   std::string odom_frame_, map_frame_, base_frame_, map_name_;
-  std::vector<std::string> laser_topics_;
+  std::vector<std::string> odom_frames_, base_frames_, laser_topics_;
   ros::Duration transform_timeout_, tf_buffer_dur_, minimum_time_interval_;
   int throttle_scans_;
 
@@ -124,7 +125,7 @@ protected:
 
   // helpers
   std::unique_ptr<laser_utils::LaserAssistant> laser_assistant_;
-  std::unique_ptr<pose_utils::GetPoseHelper> pose_helper_;
+  std::vector<std::unique_ptr<pose_utils::GetPoseHelper>> pose_helpers_;
   std::unique_ptr<map_saver::MapSaver> map_saver_;
   std::unique_ptr<loop_closure_assistant::LoopClosureAssistant> closure_assistant_;
   std::unique_ptr<laser_utils::ScanHolder> scan_holder_;

--- a/slam_toolbox/include/slam_toolbox/slam_toolbox_localization.hpp
+++ b/slam_toolbox/include/slam_toolbox/slam_toolbox_localization.hpp
@@ -35,7 +35,7 @@ public:
 
 protected:
   virtual void laserCallback(
-    const sensor_msgs::LaserScan::ConstPtr& scan) override final;
+    const sensor_msgs::LaserScan::ConstPtr& scan, const std::string& base_frame_id) override final;
   void localizePoseCallback(
     const geometry_msgs::PoseWithCovarianceStampedConstPtr& msg);
 

--- a/slam_toolbox/include/slam_toolbox/slam_toolbox_sync.hpp
+++ b/slam_toolbox/include/slam_toolbox/slam_toolbox_sync.hpp
@@ -33,7 +33,7 @@ public:
   void run();
 
 protected:
-  virtual void laserCallback(const sensor_msgs::LaserScan::ConstPtr& scan) override final;
+  virtual void laserCallback(const sensor_msgs::LaserScan::ConstPtr& scan, const std::string& base_frame_id) override final;
   bool clearQueueCallback(slam_toolbox_msgs::ClearQueue::Request& req, slam_toolbox_msgs::ClearQueue::Response& resp);
   virtual bool deserializePoseGraphCallback(slam_toolbox_msgs::DeserializePoseGraph::Request& req,
     slam_toolbox_msgs::DeserializePoseGraph::Response& resp) override final;

--- a/slam_toolbox/lib/karto_sdk/src/Mapper.cpp
+++ b/slam_toolbox/lib/karto_sdk/src/Mapper.cpp
@@ -1513,7 +1513,7 @@ namespace karto
         kt_double response = m_pMapper->m_pSequentialScanMatcher->MatchScan<LocalizedRangeScanMap>(pScan,
                                                                   pSensorManager->GetScans(rCandidateSensorName),
                                                                   bestPose, covariance);
-        LinkScans(pScan, pSensorManager->GetScan(rCandidateSensorName, 0), bestPose, covariance);
+        LinkScans(pSensorManager->GetScan(rCandidateSensorName, 0), pScan, bestPose, covariance);
 
         // only add to means and covariances if response was high "enough"
         if (response > m_pMapper->m_pLinkMatchMinimumResponseFine->GetValue())

--- a/slam_toolbox/src/experimental/slam_toolbox_lifelong.cpp
+++ b/slam_toolbox/src/experimental/slam_toolbox_lifelong.cpp
@@ -71,15 +71,12 @@ void LifelongSlamToolbox::laserCallback(
 {
   // no odom info on any pose helper
   karto::Pose2 pose;
-  bool found_odom = false;
-  for(size_t idx = 0; idx < pose_helpers_.size(); idx++)
-  {
-    found_odom = pose_helpers_[idx]->getOdomPose(pose, scan->header.stamp, scan->header.frame_id);
-    if(found_odom)
-      break;
-  }
-  if(!found_odom)
+  if(pose_helpers_.find(base_frame_id) == pose_helpers_.end())
     return;
+  else
+  {
+    pose_helpers_[base_frame_id]->getOdomPose(pose, scan->header.stamp, base_frame_id);
+  }
 
   // ensure the laser can be used
   LaserRangeFinder* laser = getLaser(scan);

--- a/slam_toolbox/src/experimental/slam_toolbox_lifelong.cpp
+++ b/slam_toolbox/src/experimental/slam_toolbox_lifelong.cpp
@@ -66,7 +66,7 @@ LifelongSlamToolbox::LifelongSlamToolbox(ros::NodeHandle& nh)
 
 /*****************************************************************************/
 void LifelongSlamToolbox::laserCallback(
-  const sensor_msgs::LaserScan::ConstPtr& scan)
+  const sensor_msgs::LaserScan::ConstPtr& scan, const std::string& base_frame_id)
 /*****************************************************************************/
 {
   // no odom info on any pose helper

--- a/slam_toolbox/src/experimental/slam_toolbox_lifelong.cpp
+++ b/slam_toolbox/src/experimental/slam_toolbox_lifelong.cpp
@@ -69,12 +69,17 @@ void LifelongSlamToolbox::laserCallback(
   const sensor_msgs::LaserScan::ConstPtr& scan)
 /*****************************************************************************/
 {
-  // no odom info
-  Pose2 pose;
-  if(!pose_helper_->getOdomPose(pose, scan->header.stamp))
+  // no odom info on any pose helper
+  karto::Pose2 pose;
+  bool found_odom = false;
+  for(size_t idx = 0; idx < pose_helpers_.size(); idx++)
   {
-    return;
+    found_odom = pose_helpers_[idx]->getOdomPose(pose, scan->header.stamp, scan->header.frame_id);
+    if(found_odom)
+      break;
   }
+  if(!found_odom)
+    return;
 
   // ensure the laser can be used
   LaserRangeFinder* laser = getLaser(scan);

--- a/slam_toolbox/src/laser_utils.cpp
+++ b/slam_toolbox/src/laser_utils.cpp
@@ -92,9 +92,10 @@ LaserMetadata LaserAssistant::toLaserMetadata(sensor_msgs::LaserScan scan)
 
 karto::LaserRangeFinder* LaserAssistant::makeLaser(const double& mountingYaw)
 {
+  const std::string name = scan_.header.frame_id;
   karto::LaserRangeFinder* laser = 
     karto::LaserRangeFinder::CreateLaserRangeFinder(
-    karto::LaserRangeFinder_Custom, karto::Name("Custom Described Lidar"));
+    karto::LaserRangeFinder_Custom, karto::Name(name.c_str())); // Sets name to laser frame
   laser->SetOffsetPose(karto::Pose2(laser_pose_.transform.translation.x,
     laser_pose_.transform.translation.y, mountingYaw));
   laser->SetMinimumRange(scan_.range_min);

--- a/slam_toolbox/src/slam_toolbox_async.cpp
+++ b/slam_toolbox/src/slam_toolbox_async.cpp
@@ -32,7 +32,7 @@ AsynchronousSlamToolbox::AsynchronousSlamToolbox(ros::NodeHandle& nh)
 
 /*****************************************************************************/
 void AsynchronousSlamToolbox::laserCallback(
-  const sensor_msgs::LaserScan::ConstPtr& scan)
+  const sensor_msgs::LaserScan::ConstPtr& scan, const std::string& base_frame_id)
 /*****************************************************************************/
 {
   // no odom info on any pose helper
@@ -40,13 +40,23 @@ void AsynchronousSlamToolbox::laserCallback(
   bool found_odom = false;
   for(size_t idx = 0; idx < pose_helpers_.size(); idx++)
   {
-    found_odom = pose_helpers_[idx]->getOdomPose(pose, scan->header.stamp, scan->header.frame_id);
+    // try compute odometry
+    found_odom = pose_helpers_[idx]->getOdomPose(pose, scan->header.stamp, base_frame_id);
     if(found_odom)
       break;
   }
   if(!found_odom)
     return;
 
+  // Add new sensor to laser ID map, and to laser assistants
+  {
+    boost::mutex::scoped_lock l(laser_id_map_mutex_);
+    if(m_laser_id_to_base_id_.find(scan->header.frame_id) == m_laser_id_to_base_id_.end())
+    {
+      m_laser_id_to_base_id_[scan->header.frame_id] = base_frame_id;
+      laser_assistants_[scan->header.frame_id] = std::make_unique<laser_utils::LaserAssistant>(nh_, tf_.get(), base_frame_id);
+    }
+  }
   // ensure the laser can be used
   karto::LaserRangeFinder* laser = getLaser(scan);
 

--- a/slam_toolbox/src/slam_toolbox_async.cpp
+++ b/slam_toolbox/src/slam_toolbox_async.cpp
@@ -35,12 +35,17 @@ void AsynchronousSlamToolbox::laserCallback(
   const sensor_msgs::LaserScan::ConstPtr& scan)
 /*****************************************************************************/
 {
-  // no odom info
+  // no odom info on any pose helper
   karto::Pose2 pose;
-  if(!pose_helper_->getOdomPose(pose, scan->header.stamp))
+  bool found_odom = false;
+  for(size_t idx = 0; idx < pose_helpers_.size(); idx++)
   {
-    return;
+    found_odom = pose_helpers_[idx]->getOdomPose(pose, scan->header.stamp, scan->header.frame_id);
+    if(found_odom)
+      break;
   }
+  if(!found_odom)
+    return;
 
   // ensure the laser can be used
   karto::LaserRangeFinder* laser = getLaser(scan);

--- a/slam_toolbox/src/slam_toolbox_async.cpp
+++ b/slam_toolbox/src/slam_toolbox_async.cpp
@@ -37,16 +37,12 @@ void AsynchronousSlamToolbox::laserCallback(
 {
   // no odom info on any pose helper
   karto::Pose2 pose;
-  bool found_odom = false;
-  for(size_t idx = 0; idx < pose_helpers_.size(); idx++)
-  {
-    // try compute odometry
-    found_odom = pose_helpers_[idx]->getOdomPose(pose, scan->header.stamp, base_frame_id);
-    if(found_odom)
-      break;
-  }
-  if(!found_odom)
+  if(pose_helpers_.find(base_frame_id) == pose_helpers_.end())
     return;
+  else
+  {
+    pose_helpers_[base_frame_id]->getOdomPose(pose, scan->header.stamp, base_frame_id);
+  }
 
   // Add new sensor to laser ID map, and to laser assistants
   {

--- a/slam_toolbox/src/slam_toolbox_common.cpp
+++ b/slam_toolbox/src/slam_toolbox_common.cpp
@@ -54,7 +54,7 @@ SlamToolbox::SlamToolbox(ros::NodeHandle& nh)
   // Set up pose helpers for each robot
   for(size_t idx = 0; idx < base_frames_.size(); idx++)
   {
-    pose_helpers_.push_back(std::make_unique<pose_utils::GetPoseHelper>(tf_.get(), base_frames_[idx], odom_frames_[idx]));
+    pose_helpers_[base_frames_[idx]] = std::make_unique<pose_utils::GetPoseHelper>(tf_.get(), base_frames_[idx], odom_frames_[idx]);
   }
   scan_holder_ = std::make_unique<laser_utils::ScanHolder>(lasers_);
   map_saver_ = std::make_unique<map_saver::MapSaver>(nh_, map_name_);
@@ -86,9 +86,9 @@ SlamToolbox::~SlamToolbox()
   dataset_.reset();
   closure_assistant_.reset();
   map_saver_.reset();
-  for(size_t idx = 0; idx < pose_helpers_.size(); idx++)
+  for(std::map<std::string,std::unique_ptr<pose_utils::GetPoseHelper>>::iterator it = pose_helpers_.begin(); it != pose_helpers_.end(); it++)
   {
-    pose_helpers_[idx].reset();
+    it->second.reset();
   }
   for(std::map<std::string,std::unique_ptr<laser_utils::LaserAssistant>>::iterator it = laser_assistants_.begin(); it != laser_assistants_.end(); it++)
   {

--- a/slam_toolbox/src/slam_toolbox_common.cpp
+++ b/slam_toolbox/src/slam_toolbox_common.cpp
@@ -206,10 +206,15 @@ void SlamToolbox::publishTransformLoop(const double& transform_publish_period)
   while(ros::ok())
   {
     {
+      // Create copy of map-to-odom TFs map
+      std::map<std::string, tf2::Transform> local_TFs_map;
+      {
+        boost::mutex::scoped_lock lock(map_to_odom_mutex_);
+        local_TFs_map = m_map_to_odoms_;
+      }
       // Publish all past and current transforms so none of them go stale
-      boost::mutex::scoped_lock lock(map_to_odom_mutex_);
-      std::map<std::string, tf2::Transform>::iterator iter;
-      for(iter = m_map_to_odoms_.begin(); iter != m_map_to_odoms_.end(); iter++)
+      std::map<std::string, tf2::Transform>::const_iterator iter;
+      for(iter = local_TFs_map.begin(); iter != local_TFs_map.end(); iter++)
       {
         geometry_msgs::TransformStamped msg;
         tf2::convert(iter->second, msg.transform);

--- a/slam_toolbox/src/slam_toolbox_common.cpp
+++ b/slam_toolbox/src/slam_toolbox_common.cpp
@@ -40,6 +40,10 @@ SlamToolbox::SlamToolbox(ros::NodeHandle& nh)
   setROSInterfaces(nh_);
   setSolver(nh_);
 
+  if(base_frames_.size() != laser_topics_.size())
+    ROS_FATAL("[RoboSAR:slam_toolbox_common:SlamToolbox] base_frames_.size() != laser_topics_.size()");
+  if(base_frames_.size() != odom_frames_.size())
+    ROS_FATAL("[RoboSAR:slam_toolbox_common:SlamToolbox] base_frames_.size() != odom_frames_.size()");
   assert(base_frames_.size() == laser_topics_.size());
   assert(base_frames_.size() == odom_frames_.size());
 

--- a/slam_toolbox/src/slam_toolbox_common.cpp
+++ b/slam_toolbox/src/slam_toolbox_common.cpp
@@ -369,11 +369,12 @@ bool SlamToolbox::updateMap()
 tf2::Stamped<tf2::Transform> SlamToolbox::setTransformFromPoses(
   const karto::Pose2& corrected_pose,
   const karto::Pose2& karto_pose,
-  const ros::Time& t,
+  const std_msgs::Header& header,
   const bool& update_reprocessing_transform)
 /*****************************************************************************/
 {
   // Compute the map->odom transform
+  const ros::Time& t = header.stamp;
   tf2::Stamped<tf2::Transform> odom_to_map;
   tf2::Quaternion q(0.,0.,0.,1.0);
   q.setRPY(0., 0., corrected_pose.GetHeading());
@@ -558,7 +559,7 @@ karto::LocalizedRangeScan* SlamToolbox::addScan(
     }
 
     setTransformFromPoses(range_scan->GetCorrectedPose(), karto_pose,
-      scan->header.stamp, update_reprocessing_transform);
+      scan->header, update_reprocessing_transform);
     dataset_->Add(range_scan);
   }
   else

--- a/slam_toolbox/src/slam_toolbox_localization.cpp
+++ b/slam_toolbox/src/slam_toolbox_localization.cpp
@@ -101,7 +101,7 @@ bool LocalizationSlamToolbox::deserializePoseGraphCallback(
 
 /*****************************************************************************/
 void LocalizationSlamToolbox::laserCallback(
-  const sensor_msgs::LaserScan::ConstPtr& scan)
+  const sensor_msgs::LaserScan::ConstPtr& scan, const std::string& base_frame_id)
 /*****************************************************************************/
 {
 // no odom info on any pose helper

--- a/slam_toolbox/src/slam_toolbox_localization.cpp
+++ b/slam_toolbox/src/slam_toolbox_localization.cpp
@@ -193,7 +193,7 @@ LocalizedRangeScan* LocalizationSlamToolbox::addScan(
   } else {
     // compute our new transform
     setTransformFromPoses(range_scan->GetCorrectedPose(), karto_pose,
-      scan->header.stamp, update_reprocessing_transform);
+      scan->header, update_reprocessing_transform);
   }
 
   return range_scan;

--- a/slam_toolbox/src/slam_toolbox_localization.cpp
+++ b/slam_toolbox/src/slam_toolbox_localization.cpp
@@ -106,15 +106,12 @@ void LocalizationSlamToolbox::laserCallback(
 {
 // no odom info on any pose helper
   karto::Pose2 pose;
-  bool found_odom = false;
-  for(size_t idx = 0; idx < pose_helpers_.size(); idx++)
-  {
-    found_odom = pose_helpers_[idx]->getOdomPose(pose, scan->header.stamp, scan->header.frame_id);
-    if(found_odom)
-      break;
-  }
-  if(!found_odom)
+  if(pose_helpers_.find(base_frame_id) == pose_helpers_.end())
     return;
+  else
+  {
+    pose_helpers_[base_frame_id]->getOdomPose(pose, scan->header.stamp, base_frame_id);
+  }
 
   // ensure the laser can be used
   LaserRangeFinder* laser = getLaser(scan);

--- a/slam_toolbox/src/slam_toolbox_localization.cpp
+++ b/slam_toolbox/src/slam_toolbox_localization.cpp
@@ -104,12 +104,17 @@ void LocalizationSlamToolbox::laserCallback(
   const sensor_msgs::LaserScan::ConstPtr& scan)
 /*****************************************************************************/
 {
-  // no odom info
-  Pose2 pose;
-  if(!pose_helper_->getOdomPose(pose, scan->header.stamp))
+// no odom info on any pose helper
+  karto::Pose2 pose;
+  bool found_odom = false;
+  for(size_t idx = 0; idx < pose_helpers_.size(); idx++)
   {
-    return;
+    found_odom = pose_helpers_[idx]->getOdomPose(pose, scan->header.stamp, scan->header.frame_id);
+    if(found_odom)
+      break;
   }
+  if(!found_odom)
+    return;
 
   // ensure the laser can be used
   LaserRangeFinder* laser = getLaser(scan);

--- a/slam_toolbox/src/slam_toolbox_sync.cpp
+++ b/slam_toolbox/src/slam_toolbox_sync.cpp
@@ -70,16 +70,12 @@ void SynchronousSlamToolbox::laserCallback(
 {
   // no odom info on any pose helper
   karto::Pose2 pose;
-  bool found_odom = false;
-  for(size_t idx = 0; idx < pose_helpers_.size(); idx++)
-  {
-    // try compute odometry
-    found_odom = pose_helpers_[idx]->getOdomPose(pose, scan->header.stamp, base_frame_id);
-    if(found_odom)
-      break;
-  }
-  if(!found_odom)
+  if(pose_helpers_.find(base_frame_id) == pose_helpers_.end())
     return;
+  else
+  {
+    pose_helpers_[base_frame_id]->getOdomPose(pose, scan->header.stamp, base_frame_id);
+  }
 
   // Add new sensor to laser ID map, and to laser assistants
   {

--- a/slam_toolbox/src/slam_toolbox_sync.cpp
+++ b/slam_toolbox/src/slam_toolbox_sync.cpp
@@ -68,12 +68,17 @@ void SynchronousSlamToolbox::laserCallback(
   const sensor_msgs::LaserScan::ConstPtr& scan)
 /*****************************************************************************/
 {
-  // no odom info
+  // no odom info on any pose helper
   karto::Pose2 pose;
-  if(!pose_helper_->getOdomPose(pose, scan->header.stamp))
+  bool found_odom = false;
+  for(size_t idx = 0; idx < pose_helpers_.size(); idx++)
   {
-    return;
+    found_odom = pose_helpers_[idx]->getOdomPose(pose, scan->header.stamp, scan->header.frame_id);
+    if(found_odom)
+      break;
   }
+  if(!found_odom)
+    return;
 
   // ensure the laser can be used
   karto::LaserRangeFinder* laser = getLaser(scan);

--- a/slam_toolbox/src/slam_toolbox_sync.cpp
+++ b/slam_toolbox/src/slam_toolbox_sync.cpp
@@ -65,7 +65,7 @@ void SynchronousSlamToolbox::run()
 
 /*****************************************************************************/
 void SynchronousSlamToolbox::laserCallback(
-  const sensor_msgs::LaserScan::ConstPtr& scan)
+  const sensor_msgs::LaserScan::ConstPtr& scan, const std::string& base_frame_id)
 /*****************************************************************************/
 {
   // no odom info on any pose helper
@@ -73,13 +73,23 @@ void SynchronousSlamToolbox::laserCallback(
   bool found_odom = false;
   for(size_t idx = 0; idx < pose_helpers_.size(); idx++)
   {
-    found_odom = pose_helpers_[idx]->getOdomPose(pose, scan->header.stamp, scan->header.frame_id);
+    // try compute odometry
+    found_odom = pose_helpers_[idx]->getOdomPose(pose, scan->header.stamp, base_frame_id);
     if(found_odom)
       break;
   }
   if(!found_odom)
     return;
 
+  // Add new sensor to laser ID map, and to laser assistants
+  {
+    boost::mutex::scoped_lock l(laser_id_map_mutex_);
+    if(m_laser_id_to_base_id_.find(scan->header.frame_id) == m_laser_id_to_base_id_.end())
+    {
+      m_laser_id_to_base_id_[scan->header.frame_id] = base_frame_id;
+      laser_assistants_[scan->header.frame_id] = std::make_unique<laser_utils::LaserAssistant>(nh_, tf_.get(), base_frame_id);
+    }
+  }
   // ensure the laser can be used
   karto::LaserRangeFinder* laser = getLaser(scan);
 


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (#76) |
| Primary OS tested on | (Ubuntu 20.04) |
| Robotic platform tested on | (Gazebo simulation, Khepera IV robots with LRF modules) |

---
**Multi-robot mapping in Gazebo**
![mrslam_mapping](https://user-images.githubusercontent.com/89307447/196056619-34733242-a3ef-465e-ab16-87a75c9bdf2d.gif)
**Multi-robot loop closure in Gazebo**
![mrslam_loopclosure](https://user-images.githubusercontent.com/89307447/196056630-fe6a2e13-2479-4885-8afd-0f60155c8355.gif)
**Mapping Tepper Locker Area using 5 Kheepra IV Robots**
![mrslam_fvd_compressed](https://user-images.githubusercontent.com/89307447/204441556-b0b030e4-0a6c-4f7d-8b11-1166c62dac7b.gif)


Much of this work was originally done for [RoboSAR](https://mrsdprojects.ri.cmu.edu/2022teamf/) (Carnegie Mellon University, Advanced Agent-Robotics Technology Lab; capstone project for Master in Robotics Systems Development 2023), a multi-robot search and rescue system. Part of the MrSLAM system has been ported for this PR; see the relevant pages here ([organization](https://github.com/orgs/MRSD-Team-RoboSAR), [MrSLAM repo](https://github.com/MRSD-Team-RoboSAR/robosar_SLAM_toolbox))

## Description of contribution in a few bullet points
* **Extends SLAM to map and localize multiple robots, each with one laser scanner**
* **Also does multi-robot loop closure**
* Fixes bug where first constraint between robots is not computed properly; this is fixed in ros2 branch already
* All robots add to and build on the same pose graph

## Description of documentation updates required from your changes
* **Robots must start close to each other, facing the same thing; relative poses are determined using laser scan matching!!!**
* First robot to come online defines world origin
* odom_frame and base_frame are now odom_frames and base_frames
* scan_topic is now laser_topics
* **number of elements in odom_frames, base_frames, and laser_topics must all be equal, one for each robot**
* Laser is named after laser frame instead of "Custom Described Lidar"

---

## Future work that may be required in bullet points
* **Tested for online sync and async modes; need testing for other modes as well**
* **Unsure how to handle multiple laser scan topics in loadSerializedPoseGraph**
* May want to have different loop closure parameters for single robot loop closing on itself, and between loop closing across multiple agents
* Add param to disable multi-robot loop closure, in case application does not want this
* Currently only supports robots with one laser scanner each; extend to multiple lasers
* Laser scan matching is used to determine initial relative poses. Useful to have different parameters for initial laser scan matching (which may require searching over a much larger space; fine since done during startup) than laser scan matching being done normally during operation
