### PR TITLE
restrction of resolution, throttle_scans and scan_buffer params to avoid illegal access of memory. 

### DIFF
--- a/src/slam_mapper.cpp
+++ b/src/slam_mapper.cpp
@@ -129,14 +129,25 @@ void SMapper::configure(const rclcpp::Node::SharedPtr & node)
     node->declare_parameter("scan_buffer_size", scan_buffer_size);
   }
   node->get_parameter("scan_buffer_size", scan_buffer_size);
+  if (scan_buffer_size <= 0) {
+    RCLCPP_WARN(node->get_logger(),
+      "You've set scan_buffer_size to be a value smaller than zero,"
+      "this isn't allowed so it will be set to default value 10.");
+    scan_buffer_size = 10;
+  }
   mapper_->setParamScanBufferSize(scan_buffer_size);
-
 
   double scan_buffer_maximum_scan_distance = 10;
   if (!node->has_parameter("scan_buffer_maximum_scan_distance")) {
     node->declare_parameter("scan_buffer_maximum_scan_distance", scan_buffer_maximum_scan_distance);
   }
   node->get_parameter("scan_buffer_maximum_scan_distance", scan_buffer_maximum_scan_distance);
+  if (math::Square(scan_buffer_maximum_scan_distance) <= 1e-06) {
+    RCLCPP_WARN(node->get_logger(),
+      "You've set scan_buffer_maximum_scan_distance to be a value whose square is smaller than 1e-06,"
+      "this isn't allowed so it will be set to default value 10.");
+    scan_buffer_maximum_scan_distance = 10;
+  }
   mapper_->setParamScanBufferMaximumScanDistance(scan_buffer_maximum_scan_distance);
 
   double link_match_minimum_response_fine = 0.1;

--- a/src/slam_toolbox_common.cpp
+++ b/src/slam_toolbox_common.cpp
@@ -135,7 +135,12 @@ void SlamToolbox::setParams()
 
   resolution_ = 0.05;
   resolution_ = this->declare_parameter("resolution", resolution_);
-
+  if (resolution_ <= 0.0) {
+    RCLCPP_WARN(node->get_logger(),
+      "You've set resolution of map to be zero or negative,"
+      "this isn't allowed so it will be set to default value 0.05.");
+    resolution_ = 0.05;
+  }
   map_name_ = std::string("/map");
   map_name_ = this->declare_parameter("map_name", map_name_);
 
@@ -147,7 +152,12 @@ void SlamToolbox::setParams()
 
   throttle_scans_ = 1;
   throttle_scans_ = this->declare_parameter("throttle_scans", throttle_scans_);
-
+  if (throttle_scans_ == 0) {
+    RCLCPP_WARN(node->get_logger(),
+      "You've set throttle_scans to be zero,"
+      "this isn't allowed so it will be set to default value 1.");
+    throttle_scans_ = 1;
+  }
   position_covariance_scale_ = 1.0;
   position_covariance_scale_ = this->declare_parameter("position_covariance_scale", position_covariance_scale_);
 


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   |   |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | gazebo simulation of turtlebot |

---

## Description of contribution in a few bullet points

resolution: if resolution < 0, when updateMap(), OccupancyGrid will have a negative width and height, which will cause overflow when processMap() since the access of new_map.data gets an index over range.

throttle_scans: must not be zero, or when scan_ctr % throttle_scans, there will be a %0 operation and lead to a mistake.

scan_buffer params: scan_buffer_size should >0 and scan_buffer_maximum_scan_distance should have a absolute value > 1e-03.
Because in AddRunningScan(), there is a operation removing all the scans when a value is larger than square(scan_buffer_maximum_scan_distance)-1e6 or the number of rest scans is larger than scan_buffer_size. If not restrict the input params, this operation will remove all the scans and still visit the scan vectors, leading to illegal access of memory.

## Description of documentation updates required from your changes

I checks all the restrictions when Param settings, if check is failed, the values are set to be default values and a warning is thrown, just like some other parameters check before.

---

## Future work that may be required in bullet points

Maybe more check for the empty vector and negative width/height.  
