### PR TITLE
Added mutex for PosedScan queue

### DIFF
--- a/slam_toolbox/include/slam_toolbox/slam_toolbox_sync.hpp
+++ b/slam_toolbox/include/slam_toolbox/slam_toolbox_sync.hpp
@@ -40,6 +40,7 @@ protected:
 
   std::queue<PosedScan> q_;
   ros::ServiceServer ssClear_;
+  boost::mutex q_mutex_;
 };
 
 }


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #547 |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Gazebo simulation of Khepera 4 with LRF module |

---

## Description of contribution in a few bullet points
* Add mutex to protect queue of PosedScans from modification from multiple threads (ros::spin and in SynchronousSlamToolbox::run)
* Kept addScan out of critical section to minimize performance impact

## Description of documentation updates required from your changes
* None
---

## Future work that may be required in bullet points
* None
