### PR TITLE
Add missing include to <mutex>

### DIFF
--- a/lib/karto_sdk/include/karto_sdk/Karto.h
+++ b/lib/karto_sdk/include/karto_sdk/Karto.h
@@ -50,6 +50,7 @@
 #include <sstream>
 #include <stdexcept>
 #include <shared_mutex>
+#include <mutex>
 
 #ifdef USE_POCO
 #include <Poco/Mutex.h>


### PR DESCRIPTION
```
In file included from $SRC_DIR/ros-humble-slam-toolbox/src/work/lib/karto_sdk/src/Karto.cpp:27: $SRC_DIR/ros-humble-slam-toolbox/src/work/lib/karto_sdk/include/karto_sdk/Karto.h: In member function 'const karto::Pose2& karto::LocalizedRangeScan::GetBarycenterPose() const': $SRC_DIR/ros-humble-slam-toolbox/src/work/lib/karto_sdk/include/karto_sdk/Karto.h:5503:12: error: 'unique_lock' is not a member of 'std'
 5503 |       std::unique_lock<std::shared_mutex> uniqueLock(m_Lock);
      |            ^~~~~~~~~~~
```
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (add tickets here #1) |
| Primary OS tested on | (Ubuntu, MacOS, Windows) |
| Robotic platform tested on | (Steve's Robot, gazebo simulation of Tally, hardware turtlebot) |

---

## Description of contribution in a few bullet points

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->
