### PR TITLE
Add missing include <mutex>

### DIFF
--- a/slam_toolbox/lib/karto_sdk/include/karto_sdk/Karto.h
+++ b/slam_toolbox/lib/karto_sdk/include/karto_sdk/Karto.h
@@ -28,6 +28,7 @@
 #include <iomanip>
 #include <sstream>
 #include <stdexcept>
+#include <mutex>
 #include <shared_mutex>
 
 #include <math.h>


### PR DESCRIPTION
Fixes:
```
In file included from $SRC_DIR/ros-noetic-slam-toolbox/src/work/lib/karto_sdk/src/Karto.cpp:25:
[4011](https://github.com/RoboStack/ros-noetic/actions/runs/3985433086/jobs/6832801759#step:3:4012)
$SRC_DIR/ros-noetic-slam-toolbox/src/work/lib/karto_sdk/include/karto_sdk/Karto.h: In member function 'const karto::Pose2& karto::LocalizedRangeScan::GetBarycenterPose() const':
[4012](https://github.com/RoboStack/ros-noetic/actions/runs/3985433086/jobs/6832801759#step:3:4013)
$SRC_DIR/ros-noetic-slam-toolbox/src/work/lib/karto_sdk/include/karto_sdk/Karto.h:5598:14: error: 'unique_lock' is not a member of 'std'
[4013](https://github.com/RoboStack/ros-noetic/actions/runs/3985433086/jobs/6832801759#step:3:4014)
 5598 |         std::unique_lock<std::shared_mutex> uniqueLock(m_Lock);
[4014](https://github.com/RoboStack/ros-noetic/actions/runs/3985433086/jobs/6832801759#step:3:4015)
      |              ^~~~~~~~~~~
[4015](https://github.com/RoboStack/ros-noetic/actions/runs/3985433086/jobs/6832801759#step:3:4016)
In file included from $SRC_DIR/ros-noetic-slam-toolbox/src/work/lib/karto_sdk/src/Karto.cpp:25:
[4016](https://github.com/RoboStack/ros-noetic/actions/runs/3985433086/jobs/6832801759#step:3:4017)
$SRC_DIR/ros-noetic-slam-toolbox/src/work/lib/karto_sdk/include/karto_sdk/Karto.h:59:1: note: 'std::unique_lock' is defined in header '<mutex>'; did you forget to '#include <mutex>'?
[4017](https://github.com/RoboStack/ros-noetic/actions/runs/3985433086/jobs/6832801759#step:3:4018)
```