### PR TITLE
In `addScan`, fix if-condition for processor_type

### DIFF
--- a/src/slam_toolbox_localization.cpp
+++ b/src/slam_toolbox_localization.cpp
@@ -150,7 +150,7 @@ LocalizedRangeScan * LocalizationSlamToolbox::addScan(
 {
   boost::mutex::scoped_lock l(pose_mutex_);
 
-  if (PROCESS_LOCALIZATION && process_near_pose_) {
+  if (processor_type_ == PROCESS_LOCALIZATION && process_near_pose_) {
     processor_type_ = PROCESS_NEAR_REGION;
   }
 


### PR DESCRIPTION

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | none |
| Primary OS tested on | none (trivial change) |
| Robotic platform tested on | none |

---

## Description of contribution in a few bullet points

* In `addScan` of the localization node, an if-condition was directly checking `if(PROCESS_LOCALIZATION && process_near_pose_)`. Since `PROCESS_LOCALIZATION` is a constant with the value 3, the first part of this condition always evaluates to true. I assume that this is a mistake, since the intent here is probably not to check if the `PROCESS_LOCALIZATION` is unequal to 0. Instead, I assume that the author meant to write: `if (processor_type_ == PROCESS_LOCALIZATION && process_near_pose_)`. If this assumption is incorrect, let me know.
* The affected line of code was initially added in [this commit](https://github.com/SteveMacenski/slam_toolbox/commit/65ec91eadfc4cb4c1f339cec814e43c64efcbd1d#diff-8936c4c9ce867bab0143e29e0586e2513ada6d77080c58fcceff15b4b6dba984R125)

## Description of documentation updates required from your changes

* none

---

## Future work that may be required in bullet points

* none
