### PR TITLE
Fix CMakeLists.txt library list

### DIFF
--- a/slam_toolbox/CMakeLists.txt
+++ b/slam_toolbox/CMakeLists.txt
@@ -62,8 +62,7 @@ catkin_package(
       ${TBB_INCLUDE_DIRS}
     LIBRARIES
       ceres_solver_plugin
-      toolbox_lib
-      slam_toolbox_rviz_plugin
+      slam_toolbox_rviz
     CATKIN_DEPENDS
       message_filters
       nav_msgs


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #612 |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | My personal robot simulation, can be seen at my `soonduck` repo |

---

## Description of contribution in a few bullet points

* In slam_toolbox package's CMakeLists.txt file, some of the libraries indicated were wrong.
* `toolbox_lib` has to be removed.
* `slam_toolbox_rviz_plugin` has to be changed into `slam_toolbox_rviz`.

## Description of documentation updates required from your changes

* No documentation update required.

---

## Future work that may be required in bullet points

* No future work required.
