### PR TITLE
added support for ROS 2 Components

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ find_package(rviz_ogre_vendor REQUIRED)
 find_package(rviz_rendering REQUIRED)
 find_package(interactive_markers REQUIRED)
 find_package(Qt5 REQUIRED COMPONENTS Core Gui Widgets Test Concurrent)
+find_package(rclcpp_components REQUIRED)
 
 #karto_sdk lib
 set(BUILD_SHARED_LIBS ON)
@@ -58,6 +59,7 @@ set(dependencies
   rviz_rendering
   interactive_markers
   Qt5
+  rclcpp_components
 )
 
 set(libraries
@@ -184,6 +186,12 @@ target_link_libraries(merge_maps_kinematic kartoSlamToolbox toolbox_common)
 #  ament_add_gtest(lifelong_metrics_test test/lifelong_metrics_test.cpp)
 #  target_link_libraries(lifelong_metrics_test lifelong_slam_toolbox)
 #endif()
+
+rclcpp_components_register_nodes(async_slam_toolbox "slam_toolbox::AsynchronousSlamToolbox")
+rclcpp_components_register_nodes(sync_slam_toolbox "slam_toolbox::SynchronousSlamToolbox")
+rclcpp_components_register_nodes(localization_slam_toolbox "slam_toolbox::LocalizationSlamToolbox")
+rclcpp_components_register_nodes(lifelong_slam_toolbox "slam_toolbox::LifelongSlamToolbox")
+rclcpp_components_register_nodes(map_and_localization_slam_toolbox "slam_toolbox::MapAndLocalizationSlamToolbox")
 
 #### Install
 install(TARGETS async_slam_toolbox_node

--- a/src/experimental/slam_toolbox_lifelong.cpp
+++ b/src/experimental/slam_toolbox_lifelong.cpp
@@ -443,3 +443,10 @@ double LifelongSlamToolbox::computeReadingOverlapRatio(
 }
 
 }  // namespace slam_toolbox
+
+#include "rclcpp_components/register_node_macro.hpp"
+
+// Register the component with class_loader.
+// This acts as a sort of entry point, allowing the component to be discoverable when its library
+// is being loaded into a running process.
+RCLCPP_COMPONENTS_REGISTER_NODE(slam_toolbox::LifelongSlamToolbox)

--- a/src/experimental/slam_toolbox_map_and_localization.cpp
+++ b/src/experimental/slam_toolbox_map_and_localization.cpp
@@ -175,3 +175,10 @@ LocalizedRangeScan * MapAndLocalizationSlamToolbox::addScan(
 }
 
 }  // namespace slam_toolbox
+
+#include "rclcpp_components/register_node_macro.hpp"
+
+// Register the component with class_loader.
+// This acts as a sort of entry point, allowing the component to be discoverable when its library
+// is being loaded into a running process.
+RCLCPP_COMPONENTS_REGISTER_NODE(slam_toolbox::MapAndLocalizationSlamToolbox)

--- a/src/slam_toolbox_async.cpp
+++ b/src/slam_toolbox_async.cpp
@@ -73,3 +73,10 @@ bool AsynchronousSlamToolbox::deserializePoseGraphCallback(
 }
 
 }  // namespace slam_toolbox
+
+#include "rclcpp_components/register_node_macro.hpp"
+
+// Register the component with class_loader.
+// This acts as a sort of entry point, allowing the component to be discoverable when its library
+// is being loaded into a running process.
+RCLCPP_COMPONENTS_REGISTER_NODE(slam_toolbox::AsynchronousSlamToolbox)

--- a/src/slam_toolbox_localization.cpp
+++ b/src/slam_toolbox_localization.cpp
@@ -239,3 +239,10 @@ void LocalizationSlamToolbox::localizePoseCallback(
 }
 
 }  // namespace slam_toolbox
+
+#include "rclcpp_components/register_node_macro.hpp"
+
+// Register the component with class_loader.
+// This acts as a sort of entry point, allowing the component to be discoverable when its library
+// is being loaded into a running process.
+RCLCPP_COMPONENTS_REGISTER_NODE(slam_toolbox::LocalizationSlamToolbox)

--- a/src/slam_toolbox_sync.cpp
+++ b/src/slam_toolbox_sync.cpp
@@ -131,3 +131,10 @@ bool SynchronousSlamToolbox::deserializePoseGraphCallback(
 }
 
 }  // namespace slam_toolbox
+
+#include "rclcpp_components/register_node_macro.hpp"
+
+// Register the component with class_loader.
+// This acts as a sort of entry point, allowing the component to be discoverable when its library
+// is being loaded into a running process.
+RCLCPP_COMPONENTS_REGISTER_NODE(slam_toolbox::SynchronousSlamToolbox)


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (#651)  |
| Primary OS tested on | (Ubuntu) |
| Robotic platform tested on | (gazebo simulation of [PMB2](https://github.com/pal-robotics/pmb2_simulation), hardware [PMB2](https://github.com/pal-robotics/pmb2_robot)) |

---

## Description of contribution in a few bullet points

* Added support to [ROS 2 Composition](https://docs.ros.org/en/humble/Concepts/Intermediate/About-Composition.html)
* Updated dependencies


```
~$ ros2 component types
slam_toolbox
  slam_toolbox::AsynchronousSlamToolbox
  slam_toolbox::SynchronousSlamToolbox
  slam_toolbox::LocalizationSlamToolbox
  slam_toolbox::LifelongSlamToolbox
  slam_toolbox::MapAndLocalizationSlamToolbox
```


## Description of documentation updates required from your changes

`slam_toolbox` Nodes can be composed as any other [Nav2 Node](https://github.com/ros-planning/navigation2/blob/main/nav2_bringup/launch/navigation_launch.py#L218).
It might not really affect the `slam_toolbox` documentation but we might consider changing https://github.com/ros-planning/navigation2/blob/main/nav2_bringup/launch/slam_launch.py to use the "Composable" version of the `slam_toolbox` Nodes
