### PR TITLE
allow slam_params_file passed as launch arg (prior was hard coded)

### DIFF
--- a/launch/localization_launch.py
+++ b/launch/localization_launch.py
@@ -1,17 +1,43 @@
+
+# Modified slowrunner: to take params_file parameter
+
+import os
+
 from launch import LaunchDescription
-import launch_ros.actions
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
 from ament_index_python.packages import get_package_share_directory
 
 
 def generate_launch_description():
-    return LaunchDescription([
-        launch_ros.actions.Node(
-          parameters=[
-            get_package_share_directory("slam_toolbox") + '/config/mapper_params_localization.yaml'
-          ],
-          package='slam_toolbox',
-          executable='localization_slam_toolbox_node',
-          name='slam_toolbox',
-          output='screen'
-        )
-    ])
+    use_sim_time = LaunchConfiguration('use_sim_time')
+    slam_params_file = LaunchConfiguration('slam_params_file')
+
+    declare_use_sim_time_argument = DeclareLaunchArgument(
+        'use_sim_time',
+        default_value='true',
+        description='Use simulation/Gazebo clock')
+    declare_slam_params_file_cmd = DeclareLaunchArgument(
+        'slam_params_file',
+        default_value=os.path.join(get_package_share_directory("slam_toolbox"),
+                                   'config', 'mapper_params_localization.yaml'),
+        description='Full path to the ROS2 parameters file to use for the slam_toolbox node')
+
+    start_localization_slam_toolbox_node = Node(
+        parameters=[
+          slam_params_file,
+          {'use_sim_time': use_sim_time}
+        ],
+        package='slam_toolbox',
+        executable='localization_slam_toolbox_node',
+        name='slam_toolbox',
+        output='screen')
+
+    ld = LaunchDescription()
+
+    ld.add_action(declare_use_sim_time_argument)
+    ld.add_action(declare_slam_params_file_cmd)
+    ld.add_action(start_localization_slam_toolbox_node)
+
+    return ld

--- a/launch/localization_launch.py
+++ b/launch/localization_launch.py
@@ -1,6 +1,4 @@
 
-# Modified slowrunner: to take params_file parameter
-
 import os
 
 from launch import LaunchDescription


### PR DESCRIPTION

## Basic Info

| Info |  |
| ------ | ----------- |
| Ticket(s) this addresses   | #654  |
| Primary OS tested on | Ubuntu 22.04 (native and dockerized) |
| Robotic platform tested on | Hardware-ROS 2 Humble GoPiGo3, and ROS 2 Humble Docker on Pi5 PiOS Bookworm |

---

## Description

* All the launch files took a mapping_params_file launch argument **Except** localization_launch.py
* This localization_launch.py matches the other launch files' style and accepts mapping_params file launch arg


## Description of documentation updates required from your changes

* None - could not find any existing documentation that is impacted by this change

---

## Future work 

* None required