### PR TITLE
Ceres solver: check parameters exist before removing them [melodic]

### DIFF
--- a/slam_toolbox/solvers/ceres_solver.cpp
+++ b/slam_toolbox/solvers/ceres_solver.cpp
@@ -369,7 +369,7 @@ void CeresSolver::RemoveNode(kt_int32s id)
     }
     else
     {
-      ROS_ERROR("RemoveNode: Failed to remove parameter blocks for node id %d", nodeit->first);
+      ROS_DEBUG("RemoveNode: Failed to remove parameter blocks for node id %d", nodeit->first);
     }
     nodes_->erase(nodeit);
   }

--- a/slam_toolbox/solvers/ceres_solver.cpp
+++ b/slam_toolbox/solvers/ceres_solver.cpp
@@ -358,6 +358,19 @@ void CeresSolver::RemoveNode(kt_int32s id)
   GraphIterator nodeit = nodes_->find(id);
   if (nodeit != nodes_->end())
   {
+    if (problem_->HasParameterBlock(&nodeit->second(0)) &&
+        problem_->HasParameterBlock(&nodeit->second(1)) &&
+        problem_->HasParameterBlock(&nodeit->second(2)))
+    {
+      problem_->RemoveParameterBlock(&nodeit->second(0));
+      problem_->RemoveParameterBlock(&nodeit->second(1));
+      problem_->RemoveParameterBlock(&nodeit->second(2));
+      ROS_DEBUG("RemoveNode: Removed node id %d", nodeit->first);
+    }
+    else
+    {
+      ROS_ERROR("RemoveNode: Failed to remove parameter blocks for node id %d", nodeit->first);
+    }
     nodes_->erase(nodeit);
   }
   else


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #398 and #419 |
| Primary OS tested on | Ubuntu 20.04 |
| Robotic platform tested on | rosbag |

---

## Description of contribution in a few bullet points
* This fix is for localization mode, to make the Cerer solver work normally after removing nodes. This issue has been described in detail in #398. 
* This also fixes the crash issue when calling the /initialpose 2 times continuously #419. Because parameters have not been added to the problem when we clear the localization buffer at the second call. So an existence check before removing should fix this issue.

## Description of documentation updates required from your changes

No documentation change is needed

## Future work that may be required in bullet points

No future work required
