### PR TITLE
Ceres solver: check parameters exist before removing them [ros2]

### DIFF
--- a/solvers/ceres_solver.cpp
+++ b/solvers/ceres_solver.cpp
@@ -398,6 +398,24 @@ void CeresSolver::RemoveNode(kt_int32s id)
   boost::mutex::scoped_lock lock(nodes_mutex_);
   GraphIterator nodeit = nodes_->find(id);
   if (nodeit != nodes_->end()) {
+    if (problem_->HasParameterBlock(&nodeit->second(0)) &&
+        problem_->HasParameterBlock(&nodeit->second(1)) &&
+        problem_->HasParameterBlock(&nodeit->second(2)))
+    {
+      problem_->RemoveParameterBlock(&nodeit->second(0));
+      problem_->RemoveParameterBlock(&nodeit->second(1));
+      problem_->RemoveParameterBlock(&nodeit->second(2));
+      RCLCPP_DEBUG(
+        logger_,
+        "RemoveNode: Removed node id %d" ,nodeit->first);
+    }
+    else
+    {
+      RCLCPP_ERROR(
+        logger_,
+        "RemoveNode: Missing parameter blocks for "
+        "node id %d", nodeit->first);
+    }
     nodes_->erase(nodeit);
   } else {
     RCLCPP_ERROR(

--- a/solvers/ceres_solver.cpp
+++ b/solvers/ceres_solver.cpp
@@ -411,7 +411,7 @@ void CeresSolver::RemoveNode(kt_int32s id)
     }
     else
     {
-      RCLCPP_ERROR(
+      RCLCPP_DEBUG(
         logger_,
         "RemoveNode: Missing parameter blocks for "
         "node id %d", nodeit->first);


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #398 and #419 |
| Primary OS tested on | Ubuntu 20.04, ROS Noetic|
| Robotic platform tested on | rosbag |

---

## Description of contribution in a few bullet points
* This fix is for localization mode, to make the Cerer solver work normally after removing nodes. This issue has been described in detail in #398. 
* This also fixes the crash issue when calling the /initialpose 2 times continuously #419. Because parameters have not been added to the problem when we clear the localization buffer at the second call. So an existence check before removing should fix this issue.

## Description of documentation updates required from your changes

No documentation change is needed

## Future work that may be required in bullet points

No future work required