### PR TITLE
Merge Maps: Transformation of box points has been fixed.

### DIFF
--- a/src/merge_maps_kinematic.cpp
+++ b/src/merge_maps_kinematic.cpp
@@ -207,11 +207,18 @@ void MergeMapsKinematic::transformScan(
   BoundingBox2 bbox = (*iter)->GetBoundingBox();
   const Vector2<kt_double> bbox_min_corr =
     applyCorrection(bbox.GetMinimum(), submap_correction);
-  bbox.SetMinimum(bbox_min_corr);
   const Vector2<kt_double> bbox_max_corr =
     applyCorrection(bbox.GetMaximum(), submap_correction);
-  bbox.SetMaximum(bbox_max_corr);
-  (*iter)->SetBoundingBox(bbox);
+  Vector2<kt_double> bbox_min_right_corr{bbox.GetMaximum().GetX(),bbox.GetMinimum().GetY()};
+  bbox_min_right_corr = applyCorrection(bbox_min_right_corr, submap_correction);
+  Vector2<kt_double> bbox_max_left_corr{bbox.GetMinimum().GetX(),bbox.GetMaximum().GetY()};
+  bbox_max_left_corr = applyCorrection(bbox_max_left_corr, submap_correction);
+  BoundingBox2 transformed_bbox;
+  transformed_bbox.Add(bbox_min_corr);
+  transformed_bbox.Add(bbox_max_corr);
+  transformed_bbox.Add(bbox_min_right_corr);
+  transformed_bbox.Add(bbox_max_left_corr);
+  (*iter)->SetBoundingBox(transformed_bbox);
 
   // TRANSFORM UNFILTERED POINTS USED
   PointVectorDouble UPR_vec = (*iter)->GetPointReadings();


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #660|
| Primary OS tested on | Ubuntu 20.04|
| Robotic platform tested on |Custom simulation environment|

---

To rotate the bounding box correctly, 4 points are needed. BoundingBox::GetMinimum() gives the lower left point and BoundingBox2::GetMaximum() gives the upper right point. When they are rotated and set to minimum and maximum again, the information from top left and bottom right is lost.
<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->
