### PR TITLE
Add Reset Map

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,7 @@ add_definitions(${EIGEN3_DEFINITIONS})
 
 rosidl_generate_interfaces(${PROJECT_NAME}
   srvs/Pause.srv
+  srvs/Reset.srv
   srvs/ClearQueue.srv
   srvs/ToggleInteractive.srv
   srvs/Clear.srv

--- a/include/slam_toolbox/slam_toolbox_common.hpp
+++ b/include/slam_toolbox/slam_toolbox_common.hpp
@@ -104,6 +104,10 @@ protected:
     const std::shared_ptr<rmw_request_id_t> request_header,
     const std::shared_ptr<slam_toolbox::srv::DeserializePoseGraph::Request> req,
     std::shared_ptr<slam_toolbox::srv::DeserializePoseGraph::Response> resp);
+  virtual bool resetCallback(
+    const std::shared_ptr<rmw_request_id_t> request_header,
+    const std::shared_ptr<slam_toolbox::srv::Reset::Request> req,
+    std::shared_ptr<slam_toolbox::srv::Reset::Response> resp);
 
   // Loaders
   void loadSerializedPoseGraph(std::unique_ptr<karto::Mapper> &, std::unique_ptr<karto::Dataset> &);
@@ -156,6 +160,7 @@ protected:
   std::shared_ptr<rclcpp::Service<slam_toolbox::srv::Pause>> ssPauseMeasurements_;
   std::shared_ptr<rclcpp::Service<slam_toolbox::srv::SerializePoseGraph>> ssSerialize_;
   std::shared_ptr<rclcpp::Service<slam_toolbox::srv::DeserializePoseGraph>> ssDesserialize_;
+  std::shared_ptr<rclcpp::Service<slam_toolbox::srv::Reset>> ssReset_;
 
   // Storage for ROS parameters
   std::string odom_frame_, map_frame_, base_frame_, map_name_, scan_topic_;

--- a/include/slam_toolbox/slam_toolbox_sync.hpp
+++ b/include/slam_toolbox/slam_toolbox_sync.hpp
@@ -46,6 +46,10 @@ protected:
     const std::shared_ptr<rmw_request_id_t> request_header,
     const std::shared_ptr<slam_toolbox::srv::DeserializePoseGraph::Request> req,
     std::shared_ptr<slam_toolbox::srv::DeserializePoseGraph::Response> resp) override;
+  bool resetCallback(
+    const std::shared_ptr<rmw_request_id_t> request_header,
+    const std::shared_ptr<slam_toolbox::srv::Reset::Request> req,
+    std::shared_ptr<slam_toolbox::srv::Reset::Response> resp) override;
 
   std::queue<PosedScan> q_;
   std::shared_ptr<rclcpp::Service<slam_toolbox::srv::ClearQueue>> ssClear_;

--- a/include/slam_toolbox/toolbox_msgs.hpp
+++ b/include/slam_toolbox/toolbox_msgs.hpp
@@ -30,6 +30,7 @@
 #include "visualization_msgs/msg/interactive_marker_feedback.hpp"
 
 #include "slam_toolbox/srv/pause.hpp"
+#include "slam_toolbox/srv/reset.hpp"
 #include "slam_toolbox/srv/clear_queue.hpp"
 #include "slam_toolbox/srv/toggle_interactive.hpp"
 #include "slam_toolbox/srv/clear.hpp"

--- a/src/slam_toolbox_common.cpp
+++ b/src/slam_toolbox_common.cpp
@@ -195,6 +195,7 @@ CallbackReturn SlamToolbox::on_deactivate(const rclcpp_lifecycle::State &)
   sstm_.reset();
   sst_.reset();
   pose_pub_.reset();
+  ssReset_.reset();
 
   if (use_lifecycle_manager_) {
     // destroy bond connection
@@ -264,6 +265,7 @@ SlamToolbox::~SlamToolbox()
   sstm_.reset();
   sst_.reset();
   pose_pub_.reset();
+  ssReset_.reset();
 
   tfB_.reset();
   tfL_.reset();
@@ -445,6 +447,10 @@ void SlamToolbox::setROSInterfaces()
   ssDesserialize_ = this->create_service<slam_toolbox::srv::DeserializePoseGraph>(
     "slam_toolbox/deserialize_map",
     std::bind(&SlamToolbox::deserializePoseGraphCallback, this,
+    std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
+  ssReset_ = this->create_service<slam_toolbox::srv::Reset>(
+    "slam_toolbox/reset",
+    std::bind(&SlamToolbox::resetCallback, this,
     std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
 
   scan_filter_sub_ =
@@ -1069,6 +1075,33 @@ bool SlamToolbox::deserializePoseGraphCallback(
         "Deserialization called without valid processor type set.");
   }
 
+  return true;
+}
+
+/*****************************************************************************/
+bool SlamToolbox::resetCallback(
+  const std::shared_ptr<rmw_request_id_t> request_header,
+  const std::shared_ptr<slam_toolbox::srv::Reset::Request> req,
+  std::shared_ptr<slam_toolbox::srv::Reset::Response> resp)
+/*****************************************************************************/
+{
+  boost::mutex::scoped_lock lock(smapper_mutex_);
+  // Reset the map.
+  smapper_->Reset();
+  smapper_->getMapper()->getScanSolver()->Reset();
+
+  // Ensure we will process the next available scan.
+  first_measurement_ = true;
+
+  // Pause new measurements processing if requested.
+  if (req->pause_new_measurements)
+  {
+    state_.set(NEW_MEASUREMENTS, true);
+    this->set_parameter({"paused_new_measurements", true});
+    RCLCPP_INFO(get_logger(), "SlamToolbox: Toggled to pause taking new measurements after reset.");
+  }
+
+  resp->result = resp->RESULT_SUCCESS;
   return true;
 }
 

--- a/src/slam_toolbox_common.cpp
+++ b/src/slam_toolbox_common.cpp
@@ -1094,11 +1094,11 @@ bool SlamToolbox::resetCallback(
   first_measurement_ = true;
 
   // Pause new measurements processing if requested.
-  if (req->pause_new_measurements)
-  {
+  if (req->pause_new_measurements) {
     state_.set(NEW_MEASUREMENTS, true);
     this->set_parameter({"paused_new_measurements", true});
-    RCLCPP_INFO(get_logger(), "SlamToolbox: Toggled to pause taking new measurements after reset.");
+    RCLCPP_INFO(get_logger(),
+      "SlamToolbox: Toggled to pause taking new measurements after reset.");
   }
 
   resp->result = resp->RESULT_SUCCESS;

--- a/src/slam_toolbox_sync.cpp
+++ b/src/slam_toolbox_sync.cpp
@@ -152,6 +152,23 @@ bool SynchronousSlamToolbox::deserializePoseGraphCallback(
   return SlamToolbox::deserializePoseGraphCallback(request_header, req, resp);
 }
 
+/*****************************************************************************/
+bool SynchronousSlamToolbox::resetCallback(
+  const std::shared_ptr<rmw_request_id_t> request_header,
+  const std::shared_ptr<slam_toolbox::srv::Reset::Request> req,
+  std::shared_ptr<slam_toolbox::srv::Reset::Response> resp)
+/*****************************************************************************/
+{
+  {
+    boost::mutex::scoped_lock lock(q_mutex_);
+    // Clear the scan queue.
+    while (!q_.empty()) {
+      q_.pop();
+    }
+  }
+  return SlamToolbox::resetCallback(request_header, req, resp);
+}
+
 }  // namespace slam_toolbox
 
 #include "rclcpp_components/register_node_macro.hpp"

--- a/srvs/Reset.srv
+++ b/srvs/Reset.srv
@@ -1,0 +1,8 @@
+# Set this to 'true' to pause new measurements immediately after reset.
+# Note: This is a set behaviour and not a toggle behaviour, contrary to Pause.srv service.
+bool pause_new_measurements
+---
+# Result code defintions
+uint8 RESULT_SUCCESS=0
+
+uint8 result

--- a/srvs/Reset.srv
+++ b/srvs/Reset.srv
@@ -1,6 +1,6 @@
 # Set this to 'true' to pause new measurements immediately after reset.
 # Note: This is a set behaviour and not a toggle behaviour, contrary to Pause.srv service.
-bool pause_new_measurements
+bool pause_new_measurements false
 ---
 # Result code defintions
 uint8 RESULT_SUCCESS=0


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #640  |
| Primary OS tested on | Ubuntu 22.04 |
| Robotic platform tested on | (Turtlebot 4 Gazebo Sim) |

---

## Description of contribution in a few bullet points

* Added a new `slam_toolbox::Reset` Service.
* Upon calling of said service, the current map will be "cleaned" and reset back to the initial state.
* A new clean map can then be generated from there.
* `slam_toolbox::Reset` request also contains a boolean `pause_new_measurements` that if set to `true`, subsequent new scans will be ignored until a `slam_toolbox::Pause` is called to resume.
* Tested with nodes: `async_slam_toolbox_node`, `sync_slam_toolbox_node`, `localization_slam_toolbox_node`

## Description of documentation updates required from your changes

* Added a new service with the default Service name: `/slam_toolbox/reset` and message type: `slam_toolbox::Reset`
* Proposed API description: `Reset current map back to the initial state`

---

## Future work that may be required in bullet points

* Considerations for experimental nodes: `map_and_localization_slam_toolbox_node`, `lifelong_slam_toolbox_node`
