### PR TITLE
Allow configurable starting localization mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ The following settings and options are exposed to you. My default configuration 
 
 `minimum_travel_distance` - Minimum distance of travel before processing a new scan
 
-`localization_on_configure` - Set to true to set the localization mode to localization during node on_configure transition. Only applies to `map_and_localization_slam_toolbox` node.
+`localization_on_configure` - Set to true to set the localization mode to localization during node on_configure transition. Set to false to set the localization mode to mapping instead. Only applies to `map_and_localization_slam_toolbox` node.
 
 ## Matcher Params
 

--- a/README.md
+++ b/README.md
@@ -263,6 +263,8 @@ The following settings and options are exposed to you. My default configuration 
 
 `minimum_travel_distance` - Minimum distance of travel before processing a new scan
 
+`localization_on_configure` - Set to true to set the localization mode to localization during node on_configure transition. Only applies to `map_and_localization_slam_toolbox` node.
+
 ## Matcher Params
 
 `use_scan_matching` - whether to use scan matching to refine odometric pose (uh, why would you not?)

--- a/src/experimental/slam_toolbox_map_and_localization.cpp
+++ b/src/experimental/slam_toolbox_map_and_localization.cpp
@@ -26,6 +26,7 @@ MapAndLocalizationSlamToolbox::MapAndLocalizationSlamToolbox(rclcpp::NodeOptions
 : LocalizationSlamToolbox(options)
 /*****************************************************************************/
 {
+  this->declare_parameter("localization_on_configure", false);
 }
 
 /*****************************************************************************/
@@ -34,7 +35,7 @@ MapAndLocalizationSlamToolbox::on_configure(const rclcpp_lifecycle::State & stat
 /*****************************************************************************/
 {
   SlamToolbox::on_configure(state);
-  toggleMode(false);
+  toggleMode(this->get_parameter("localization_on_configure").as_bool());
 
   // disable interactive mode
   enable_interactive_mode_ = false;


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | None |
| Primary OS tested on | Ubuntu 22.04 |
| Robotic platform tested on | Turtlebot 4 Gazebo Sim |

---

## Description of contribution in a few bullet points
* Added a ROS parameter (`localization_on_configure`) to allow the starting localization mode (mapping or localization) to be configurable.
* **Only** applies to `map_and_localization_slam_toolbox` experimental node.
<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

## Description of documentation updates required from your changes

* Updated `README.md` with parameter description.
<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->
