### PR TITLE
fix building on Ubuntu 24.04

### DIFF
--- a/solvers/ceres_solver.cpp
+++ b/solvers/ceres_solver.cpp
@@ -77,7 +77,7 @@ void CeresSolver::Configure(rclcpp_lifecycle::LifecycleNode::SharedPtr node)
   first_node_ = nodes_->end();
 
   // formulate problem
-  angle_local_parameterization_ = AngleLocalParameterization::Create();
+  angle_manifold_ = AngleManifold::Create();
 
   // choose loss function default squared loss (NULL)
   loss_function_ = NULL;
@@ -310,7 +310,7 @@ void CeresSolver::Reset()
   problem_ = new ceres::Problem(options_problem_);
   first_node_ = nodes_->end();
 
-  angle_local_parameterization_ = AngleLocalParameterization::Create();
+  angle_manifold_ = AngleManifold::Create();
 }
 
 /*****************************************************************************/
@@ -382,10 +382,10 @@ void CeresSolver::AddConstraint(karto::Edge<karto::LocalizedRangeScan> * pEdge)
     cost_function, loss_function_,
     &node1it->second(0), &node1it->second(1), &node1it->second(2),
     &node2it->second(0), &node2it->second(1), &node2it->second(2));
-  problem_->SetParameterization(&node1it->second(2),
-    angle_local_parameterization_);
-  problem_->SetParameterization(&node2it->second(2),
-    angle_local_parameterization_);
+  problem_->SetManifold(&node1it->second(2),
+    angle_manifold_);
+  problem_->SetManifold(&node2it->second(2),
+    angle_manifold_);
 
   blocks_->insert(std::pair<std::size_t, ceres::ResidualBlockId>(
       GetHash(node1, node2), block));

--- a/solvers/ceres_solver.hpp
+++ b/solvers/ceres_solver.hpp
@@ -7,7 +7,6 @@
 #define SOLVERS__CERES_SOLVER_HPP_
 
 #include <math.h>
-#include <ceres/local_parameterization.h>
 #include <ceres/ceres.h>
 #include <vector>
 #include <unordered_map>
@@ -68,7 +67,7 @@ private:
   ceres::Problem::Options options_problem_;
   ceres::LossFunction * loss_function_;
   ceres::Problem * problem_;
-  ceres::LocalParameterization * angle_local_parameterization_;
+  ceres::Manifold * angle_manifold_;
   bool was_constant_set_, debug_logging_;
 
   // graph


### PR DESCRIPTION
Ubuntu 24.04 updates Ceres Solver to 2.2.0 which dropped support for LocalParameterization and suggests users to move to Manifold instead.

This commit fixes slam_toolbox build on Ubuntu 24.04 **and simultaneously breaks it for Ubuntu 22.04 with Ceres 2.0.0**

The code are copied from the official slam/pose_graph_2d example:

https://ceres-solver.googlesource.com/ceres-solver/+/refs/tags/2.2.0/examples/slam/pose_graph_2d/

<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | None |
| Primary OS tested on | Ubuntu 24.04 |
| Robotic platform tested on | A rosbag I recorded last year |

---

## Description of contribution in a few bullet points

* fix building with ceres 2.2.0 on Ubuntu 24.04

## Description of documentation updates required from your changes

None

---

## Future work that may be required in bullet points

* This breaks building with ceres 2.0.0 on Ubuntu 22.04. Do not merge until it's time to switch OS version.
