### PR TITLE
replace "rclcpp::ok()" by atomic-flag to avoid UAF bug

### DIFF
--- a/include/slam_toolbox/slam_toolbox_common.hpp
+++ b/include/slam_toolbox/slam_toolbox_common.hpp
@@ -189,6 +189,7 @@ protected:
 
   // Internal state
   std::vector<std::unique_ptr<boost::thread>> threads_;
+  std::atomic<bool> stop_threads_;
   tf2::Transform map_to_odom_;
   boost::mutex map_to_odom_mutex_, smapper_mutex_, pose_mutex_;
   PausedState state_;

--- a/src/slam_toolbox_common.cpp
+++ b/src/slam_toolbox_common.cpp
@@ -41,7 +41,8 @@ SlamToolbox::SlamToolbox(rclcpp::NodeOptions options)
   first_measurement_(true),
   process_near_pose_(nullptr),
   transform_timeout_(rclcpp::Duration::from_seconds(0.5)),
-  minimum_time_interval_(std::chrono::nanoseconds(0))
+  minimum_time_interval_(std::chrono::nanoseconds(0)),
+  stop_threads_(false)
 /*****************************************************************************/
 {
   int stack_size = 40'000'000;
@@ -240,6 +241,8 @@ SlamToolbox::on_shutdown(const rclcpp_lifecycle::State & state)
 SlamToolbox::~SlamToolbox()
 /*****************************************************************************/
 {
+  stop_threads_.store(true);
+  
   for (int i = 0; i != threads_.size(); i++) {
     threads_[i]->interrupt();
     threads_[i]->join();
@@ -518,7 +521,7 @@ void SlamToolbox::publishVisualizations()
   map_update_interval = this->get_parameter("map_update_interval").as_double();
   rclcpp::Rate r(1.0 / map_update_interval);
 
-  while (rclcpp::ok()) {
+  while (!stop_threads_.load() /*atomic*/) {
     boost::this_thread::interruption_point();
     updateMap();
     if (!isPaused(VISUALIZING_GRAPH)) {

--- a/src/slam_toolbox_common.cpp
+++ b/src/slam_toolbox_common.cpp
@@ -176,6 +176,7 @@ CallbackReturn SlamToolbox::on_deactivate(const rclcpp_lifecycle::State &)
 /*****************************************************************************/
 {
   RCLCPP_INFO(get_logger(), "Deactivating");
+  stop_threads_.store(true);
   for (int i = 0; i != threads_.size(); i++) {
     threads_[i]->interrupt();
     threads_[i]->join();


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #691   |
| Primary OS tested on | Ubuntu22.04 |
| Robotic platform tested on | gazebo simulation of Tally |

---

## Description of contribution in a few bullet points

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

- add an atomic-flag for threads

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

- avoid UAF bug caused by `rclcpp::ok()` 's wrong work

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->
