### PR TITLE
[Fix]map merge misalignment

### DIFF
--- a/include/slam_toolbox/merge_maps_kinematic.hpp
+++ b/include/slam_toolbox/merge_maps_kinematic.hpp
@@ -101,6 +101,7 @@ private:
   std::map<int, Eigen::Vector3d> submap_locations_;
   std::vector<karto::LocalizedRangeScanVector> scans_vec_;
   std::map<int, tf2::Transform> submap_marker_transform_;
+  std::map<int, tf2::Transform> prev_submap_marker_transform_;
   double resolution_;
   int num_submaps_;
 };

--- a/src/merge_maps_kinematic.cpp
+++ b/src/merge_maps_kinematic.cpp
@@ -135,6 +135,7 @@ bool MergeMapsKinematic::addSubmapCallback(
   submap_marker_transform_[num_submaps_] =
     tf2::Transform(tf2::Quaternion(0., 0., 0., 1.0),
       tf2::Vector3(0, 0, 0));  // no initial correction -- identity mat
+  prev_submap_marker_transform_ = submap_marker_transform_;
   submap_locations_[num_submaps_] =
     Eigen::Vector3d(transform.getOrigin().getX(),
       transform.getOrigin().getY(), 0.);
@@ -266,11 +267,12 @@ bool MergeMapsKinematic::mergeMapCallback(
     for (LocalizedRangeScansIt iter = it_LRV->begin();
       iter != it_LRV->end(); ++iter)
     {
-      tf2::Transform submap_correction = submap_marker_transform_[id];
+      tf2::Transform submap_correction = submap_marker_transform_[id] * prev_submap_marker_transform_[id].inverse();
       transformScan(iter, submap_correction);
       transformed_scans.push_back((*iter));
     }
   }
+  prev_submap_marker_transform_ = submap_marker_transform_;
 
   // create the map
   nav_msgs::srv::GetMap::Response map;

--- a/src/merge_maps_kinematic.cpp
+++ b/src/merge_maps_kinematic.cpp
@@ -318,30 +318,33 @@ void MergeMapsKinematic::processInteractiveFeedback(
 {
   const int id = std::stoi(feedback->marker_name, nullptr, 10);
 
+  tf2::Quaternion quat(feedback->pose.orientation.x,
+    feedback->pose.orientation.y,
+    feedback->pose.orientation.z,
+    feedback->pose.orientation.w);
+  
   if (feedback->event_type ==
     visualization_msgs::msg::InteractiveMarkerFeedback::MOUSE_UP &&
     feedback->mouse_point_valid)
   {
     tf2Scalar yaw = tf2::getYaw(feedback->pose.orientation);
-    tf2::Quaternion quat(0., 0., 0., 1.0);
     tf2::fromMsg(feedback->pose.orientation, quat);  // relative
 
     tf2::Transform previous_submap_correction;
     previous_submap_correction.setIdentity();
     previous_submap_correction.setOrigin(tf2::Vector3(submap_locations_[id](0),
       submap_locations_[id](1), 0.));
-
+    previous_submap_correction.setRotation(submap_marker_transform_[id].getRotation());
     // update internal knowledge of submap locations
     submap_locations_[id] = Eigen::Vector3d(feedback->pose.position.x,
         feedback->pose.position.y,
-        submap_locations_[id](2) + yaw);
+        0.0);
 
     // add the map_N frame there
     tf2::Transform new_submap_location;
-    new_submap_location.setOrigin(tf2::Vector3(submap_locations_[id](0),
-      submap_locations_[id](1), 0.));
+    new_submap_location.setOrigin(tf2::Vector3(feedback->pose.position.x,
+      feedback->pose.position.y, 0.));
     new_submap_location.setRotation(quat);
-
     geometry_msgs::msg::TransformStamped msg;
     msg.transform = tf2::toMsg(new_submap_location);
     msg.child_frame_id = "/map_" + std::to_string(id);
@@ -349,15 +352,13 @@ void MergeMapsKinematic::processInteractiveFeedback(
     msg.header.stamp = this->now();
     tfB_->sendTransform(msg);
 
-    submap_marker_transform_[id] = submap_marker_transform_[id] *
-      previous_submap_correction.inverse() * new_submap_location;
+    submap_marker_transform_[id] = new_submap_location;
   }
 
   if (feedback->event_type ==
     visualization_msgs::msg::InteractiveMarkerFeedback::POSE_UPDATE)
   {
     tf2Scalar yaw = tf2::getYaw(feedback->pose.orientation);
-    tf2::Quaternion quat(0., 0., 0., 1.0);
     tf2::fromMsg(feedback->pose.orientation, quat);  // relative
 
     // add the map_N frame there
@@ -373,6 +374,7 @@ void MergeMapsKinematic::processInteractiveFeedback(
     msg.header.stamp = this->now();
     tfB_->sendTransform(msg);
   }
+  this->mergeMapCallback(nullptr, nullptr, nullptr);
 }
 
 /*****************************************************************************/


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #385 |
| Primary OS tested on | (Ubuntu 22.04) |
| Robotic platform tested on | Tested on [Saha Robotic's](https://github.com/saha-robotics) Service Robot Speedy |

---

## Description of contribution in a few bullet points


- Fix map merge misalignment issue.
- Add generate map when move the interactive markers.

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->
I have noticed two issues:

- When the submap is called, the submap's marker and TF are not aligned in the same location. This issue is resolved if we move the marker on the map once.
- When we rotate the map, the map size increases.