### PR TITLE
fix shouldProcessScan() to do what is advertised

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,6 +199,7 @@ rclcpp_components_register_nodes(map_and_localization_slam_toolbox "slam_toolbox
 install(TARGETS async_slam_toolbox_node
                 sync_slam_toolbox_node
                 localization_slam_toolbox_node
+		lifelong_slam_toolbox_node
                 map_and_localization_slam_toolbox_node
                 merge_maps_kinematic
                 ${libraries}

--- a/include/slam_toolbox/slam_toolbox_common.hpp
+++ b/include/slam_toolbox/slam_toolbox_common.hpp
@@ -143,7 +143,7 @@ protected:
   // Storage for ROS parameters
   std::string odom_frame_, map_frame_, base_frame_, map_name_, scan_topic_;
   bool use_map_saver_;
-  rclcpp::Duration transform_timeout_, minimum_time_interval_;
+  rclcpp::Duration transform_timeout_;
   std_msgs::msg::Header scan_header;
   int throttle_scans_, scan_queue_size_;
 

--- a/lib/karto_sdk/include/karto_sdk/Mapper.h
+++ b/lib/karto_sdk/include/karto_sdk/Mapper.h
@@ -2091,17 +2091,33 @@ public:
     return m_LocalizationScanVertices;
   }
 
-protected:
-  void InitializeParameters();
+  /**
+   * Test if the enough time has passed since the last processed scan.
+   * @param scanTime scan to be checked
+   * @param lastScanTime last scan added to mapper
+   * @return true if the minimum alloted time has passed
+   */
+  kt_bool EnoughTimeHasPassed(const kt_double& scanTime, const kt_double& lastScanTime) const;
 
   /**
    * Test if the scan is "sufficiently far" from the last scan added.
+   * @param scannerPose scanner pose to be checked
+   * @param lastScannerPose pose of the last scan added to mapper
+   * @return true if the scan is "sufficiently far" from the last scan added
+   */
+  kt_bool HasMovedEnough(const Pose2& scannerPose, const Pose2& lastScannerPose) const;
+
+  /**
+   * See if we should continue processing this scan.
    * @param pScan scan to be checked
    * @param pLastScan last scan added to mapper
-   * @return true if the scan is "sufficiently far" from the last scan added or
-   * the scan is the first scan to be added
+   * @return true if it is the first scan, if enough time has passed since the last one or 
+   * the scan pose has moved enough.
    */
-  kt_bool HasMovedEnough(LocalizedRangeScan * pScan, LocalizedRangeScan * pLastScan) const;
+  kt_bool ContinueProcessingScan(LocalizedRangeScan * pScan, LocalizedRangeScan * pLastScan) const;
+
+protected:
+  void InitializeParameters();
 
 public:
   /////////////////////////////////////////////

--- a/src/slam_mapper.cpp
+++ b/src/slam_mapper.cpp
@@ -110,6 +110,13 @@ void SMapper::configure(const rclcpp::Node::SharedPtr & node)
   node->get_parameter("use_scan_barycenter", use_scan_barycenter);
   mapper_->setParamUseScanBarycenter(use_scan_barycenter);
 
+  double minimum_time_interval = 3600;
+  if (!node->has_parameter("minimum_time_interval")) {
+    node->declare_parameter("minimum_time_interval", minimum_time_interval);
+  }
+  node->get_parameter("minimum_time_interval", minimum_time_interval);
+  mapper_->setParamMinimumTimeInterval(minimum_time_interval);
+
   double minimum_travel_distance = 0.5;
   if (!node->has_parameter("minimum_travel_distance")) {
     node->declare_parameter("minimum_travel_distance", minimum_travel_distance);

--- a/src/slam_toolbox_common.cpp
+++ b/src/slam_toolbox_common.cpp
@@ -41,8 +41,7 @@ SlamToolbox::SlamToolbox(rclcpp::NodeOptions options)
   processor_type_(PROCESS),
   first_measurement_(true),
   process_near_pose_(nullptr),
-  transform_timeout_(rclcpp::Duration::from_seconds(0.5)),
-  minimum_time_interval_(std::chrono::nanoseconds(0))
+  transform_timeout_(rclcpp::Duration::from_seconds(0.5))
 /*****************************************************************************/
 {
   smapper_ = std::make_unique<mapper_utils::SMapper>();
@@ -177,8 +176,6 @@ void SlamToolbox::setParams()
   double tmp_val = 0.5;
   tmp_val = this->declare_parameter("transform_timeout", tmp_val);
   transform_timeout_ = rclcpp::Duration::from_seconds(tmp_val);
-  tmp_val = this->declare_parameter("minimum_time_interval", tmp_val);
-  minimum_time_interval_ = rclcpp::Duration::from_seconds(tmp_val);
 
   bool debug = false;
   debug = this->declare_parameter("debug_logging", debug);


### PR DESCRIPTION

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #451 #499 #545 |
| Primary OS tested on | Ubuntu 22.04.4 LTS |
| ROS distro: | Humble  _(same issue in Rolling, but I'm using Humble for now)_ |
| Robotic platform tested on | gazebo simulation turtlebot _(actually a proprietary robot, but the same as turtlebot in all ways that matter here)_  |

---

## Description of contribution in a few bullet points
* we ensure `minimum_travel_heading` parameter does what is intended - make SLAM process scans if the robot heading has changed enough. See Issue tickets above for more info
* we refactor`Mapper::HasMovedEnough()`, breaking the function into three, so that 
   * checks advertised in `shouldProcessScan()` are implemented in a single place
   * `Mapper::HasMovedEnough()` does not do more than it says it does
* we ensure `minimum_time_interval` parameter is propagated from the ROS node to the internal `Mapper` instance
---

## Contribution in more detail

* in the `slam_toolbox_common`, there is a check whether to process the incoming scan. If the node is not paused or throttled out, we process the scan if either of these is true:
   1.  it is the first scan
   2.  if enough time has passed between two scans (as set by `minimum_time_interval`)
   3.  if the robot position has changed enough (as set by `minimum_travel_distance`)
   4.  if the robot heading has changed enough (as set by `minimum_travel_heading`)
* as it [currently stands](https://github.com/SteveMacenski/slam_toolbox/blob/94cec982a7f850818187c81295d1212f145efe37/src/slam_toolbox_common.cpp#L502-L547), the function does not check `iv` at all, and the parameter in `ii` is [set in the node](https://github.com/SteveMacenski/slam_toolbox/blob/8749e3392f80e400409da00a9e7fc401ba0818d5/src/slam_toolbox_common.cpp#L404-L405), but [is not propagated](https://github.com/SteveMacenski/slam_toolbox/blob/8749e3392f80e400409da00a9e7fc401ba0818d5/src/slam_mapper.cpp#L113) to the `Mapper` instance.
* In this PR, I propose a fix where `shouldProcessScan()` would use the [checks ](https://github.com/SteveMacenski/slam_toolbox/blob/94cec982a7f850818187c81295d1212f145efe37/lib/karto_sdk/src/Mapper.cpp#L3110-L3140) already implemented in `Mapper` class, which is already instanced in the ROS node and holds all of the relevant parameters, instead of [implementing them again](https://github.com/SteveMacenski/slam_toolbox/blob/8749e3392f80e400409da00a9e7fc401ba0818d5/src/slam_toolbox_common.cpp#L772-L780)
* Along the way, we refactor `Mapper::HasMovedEnough()` function that is also misleadingly named, as it not only checks has the robot moved enough, but also:
   * is it the first scan
   * did the robot *turn* enough
   * has enough time passed between scans
* We split this function into three functions, so its parts can be accessed from `shouldProcessScan()`, and introduce clarity into `Mapper.cpp`. It seems to me this is not a huge change, as the function `Mapper::HasMovedEnough()` is only called in two places in total, when processing scans.
* Lastly, we ensure that `minimum_time_interval` parameter is properly propagated from the ROS parameters to the internal `Mapper` instance, so that we can use the newly created `Mapper::EnoughTimeHasPassed()` function

---
