### PR TITLE
ros2 min laser range parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 snap_ws/*
+.vscode/*

--- a/README.md
+++ b/README.md
@@ -252,6 +252,8 @@ The following settings and options are exposed to you. My default configuration 
 
 `resolution` - Resolution of the 2D occupancy map to generate
 
+`min_laser_range` - Minimum laser range to use for 2D occupancy map rasterizing
+
 `max_laser_range` - Maximum laser range to use for 2D occupancy map rasterizing
 
 `minimum_time_interval` - The minimum duration of time between scans to be processed in synchronous mode

--- a/config/mapper_params_lifelong.yaml
+++ b/config/mapper_params_lifelong.yaml
@@ -40,6 +40,7 @@ slam_toolbox:
     transform_publish_period: 0.02 #if 0 never publishes odometry
     map_update_interval: 5.0
     resolution: 0.05
+    min_laser_range: 0.0 #for rastering images
     max_laser_range: 20.0 #for rastering images
     minimum_time_interval: 0.5
     transform_timeout: 0.2

--- a/config/mapper_params_localization.yaml
+++ b/config/mapper_params_localization.yaml
@@ -23,6 +23,7 @@ slam_toolbox:
     transform_publish_period: 0.02 #if 0 never publishes odometry
     map_update_interval: 5.0
     resolution: 0.05
+    min_laser_range: 0.0 #for rastering images
     max_laser_range: 20.0 #for rastering images
     minimum_time_interval: 0.5
     transform_timeout: 0.2

--- a/config/mapper_params_offline.yaml
+++ b/config/mapper_params_offline.yaml
@@ -21,6 +21,7 @@ slam_toolbox:
     transform_publish_period: 0.02 #if 0 never publishes odometry
     map_update_interval: 10.0
     resolution: 0.05
+    min_laser_range: 0.0 #for rastering images
     max_laser_range: 20.0 #for rastering images
     minimum_time_interval: 0.5
     transform_timeout: 0.2

--- a/config/mapper_params_online_async.yaml
+++ b/config/mapper_params_online_async.yaml
@@ -29,6 +29,7 @@ slam_toolbox:
     transform_publish_period: 0.02 #if 0 never publishes odometry
     map_update_interval: 5.0
     resolution: 0.05
+    min_laser_range: 0.0 #for rastering images
     max_laser_range: 20.0 #for rastering images
     minimum_time_interval: 0.5
     transform_timeout: 0.2

--- a/config/mapper_params_online_sync.yaml
+++ b/config/mapper_params_online_sync.yaml
@@ -29,6 +29,7 @@ slam_toolbox:
     transform_publish_period: 0.02 #if 0 never publishes odometry
     map_update_interval: 5.0
     resolution: 0.05
+    min_laser_range: 0.0 #for rastering images
     max_laser_range: 20.0 #for rastering images
     minimum_time_interval: 0.5
     transform_timeout: 0.2

--- a/src/laser_utils.cpp
+++ b/src/laser_utils.cpp
@@ -100,7 +100,28 @@ karto::LaserRangeFinder * LaserAssistant::makeLaser(const double & mountingYaw)
     karto::LaserRangeFinder_Custom, karto::Name("Custom Described Lidar"));
   laser->SetOffsetPose(karto::Pose2(laser_pose_.transform.translation.x,
     laser_pose_.transform.translation.y, mountingYaw));
-  laser->SetMinimumRange(scan_.range_min);
+  
+  double min_laser_range = 0.0;
+  if (!node_->has_parameter("min_laser_range")) {
+    node_->declare_parameter("min_laser_range", min_laser_range);
+  }
+  node_->get_parameter("min_laser_range", min_laser_range);
+
+  if (min_laser_range < 0) {
+    RCLCPP_WARN(node_->get_logger(),
+      "You've set minimum laser range to be negative,"
+      "this isn't allowed so it will be set to (%.1f).", scan_.range_min);
+    min_laser_range = scan_.range_min;
+  }
+
+  if (min_laser_range < scan_.range_min) {
+    RCLCPP_WARN(node_->get_logger(),
+      "minimum laser range setting (%.1f m) exceeds the capabilities "
+      "of the used Lidar (%.1f m)", min_laser_range, scan_.range_min);
+    min_laser_range = scan_.range_min;
+  }
+
+  laser->SetMinimumRange(min_laser_range);
   laser->SetMaximumRange(scan_.range_max);
   laser->SetMinimumAngle(scan_.angle_min);
   laser->SetMaximumAngle(scan_.angle_max);


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #707 #713  |
| Primary OS tested on | Ubuntu22.04 |
| Robotic platform tested on | Linorobot2 Gazebo Simmulation, My customized ROS2 robot |

---

## Description of contribution in a few bullet points

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

* I added `min_laser_range` parameter to limit the minimum range being used by the SLAM to create the map similar to `max_laser_range` parameter
* I add short description in the README.MD about the new parameter
* I add the parameter to all of the sample config file with value of 0 that will trigger the use of laser scan message minimum range


## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->
* Added new parameter, so need to add that to default configs and documentation page (I have done it in the README part)

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->
