### PR TITLE
feat: adds min_pass_through and occupancy_threshold ros parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,10 @@ The following settings and options are exposed to you. My default configuration 
 
 `use_response_expansion` - Whether to automatically increase the search grid size if no viable match is found
 
+`min_pass_through` - Number of beams that must pass through a cell before it will be considered to be occupied or unoccupied. This prevents stray beams from messing up the map.
+
+`occupancy_threshold` - Minimum ratio of beams hitting cell to beams passing through cell to be marked as occupied
+
 # Install
 
 ROSDep will take care of the major things

--- a/config/mapper_params_lifelong.yaml
+++ b/config/mapper_params_lifelong.yaml
@@ -83,3 +83,5 @@ slam_toolbox:
     minimum_angle_penalty: 0.9
     minimum_distance_penalty: 0.5
     use_response_expansion: true
+    min_pass_through: 2
+    occupancy_threshold: 0.1

--- a/config/mapper_params_localization.yaml
+++ b/config/mapper_params_localization.yaml
@@ -66,3 +66,5 @@ slam_toolbox:
     minimum_angle_penalty: 0.9
     minimum_distance_penalty: 0.5
     use_response_expansion: true
+    min_pass_through: 2
+    occupancy_threshold: 0.1

--- a/config/mapper_params_offline.yaml
+++ b/config/mapper_params_offline.yaml
@@ -65,3 +65,5 @@ slam_toolbox:
     minimum_angle_penalty: 0.9
     minimum_distance_penalty: 0.5
     use_response_expansion: true
+    min_pass_through: 2
+    occupancy_threshold: 0.1

--- a/config/mapper_params_online_async.yaml
+++ b/config/mapper_params_online_async.yaml
@@ -73,3 +73,5 @@ slam_toolbox:
     minimum_angle_penalty: 0.9
     minimum_distance_penalty: 0.5
     use_response_expansion: true
+    min_pass_through: 2
+    occupancy_threshold: 0.1

--- a/config/mapper_params_online_sync.yaml
+++ b/config/mapper_params_online_sync.yaml
@@ -73,3 +73,5 @@ slam_toolbox:
     minimum_angle_penalty: 0.9
     minimum_distance_penalty: 0.5
     use_response_expansion: true
+    min_pass_through: 2
+    occupancy_threshold: 0.1

--- a/include/slam_toolbox/merge_maps_kinematic.hpp
+++ b/include/slam_toolbox/merge_maps_kinematic.hpp
@@ -102,6 +102,8 @@ private:
   std::vector<karto::LocalizedRangeScanVector> scans_vec_;
   std::map<int, tf2::Transform> submap_marker_transform_;
   double resolution_;
+  int min_pass_through_;
+  double occupancy_threshold_;
   int num_submaps_;
 };
 

--- a/lib/karto_sdk/include/karto_sdk/Karto.h
+++ b/lib/karto_sdk/include/karto_sdk/Karto.h
@@ -5946,7 +5946,7 @@ public:
    */
   static OccupancyGrid * CreateFromScans(
     const LocalizedRangeScanVector & rScans,
-    kt_double resolution)
+    kt_double resolution, kt_int32u min_pass_through, kt_double occupancy_threshold)
   {
     if (rScans.empty()) {
       return NULL;
@@ -5956,6 +5956,8 @@ public:
     Vector2<kt_double> offset;
     ComputeDimensions(rScans, resolution, width, height, offset);
     OccupancyGrid * pOccupancyGrid = new OccupancyGrid(width, height, offset, resolution);
+    pOccupancyGrid->SetMinPassThrough(min_pass_through); 
+    pOccupancyGrid->SetOccupancyThreshold(occupancy_threshold); 
     pOccupancyGrid->CreateFromScans(rScans);
 
     return pOccupancyGrid;

--- a/lib/karto_sdk/include/karto_sdk/Mapper.h
+++ b/lib/karto_sdk/include/karto_sdk/Mapper.h
@@ -2408,8 +2408,9 @@ protected:
     ar & BOOST_SERIALIZATION_NVP(m_pMinimumAnglePenalty);
     ar & BOOST_SERIALIZATION_NVP(m_pMinimumDistancePenalty);
     ar & BOOST_SERIALIZATION_NVP(m_pUseResponseExpansion);
-    ar & BOOST_SERIALIZATION_NVP(m_pMinPassThrough);
-    ar & BOOST_SERIALIZATION_NVP(m_pOccupancyThreshold);
+// NOTE: the following two lines are commented out to avoid breaking the serialization of already existing maps
+//    ar & BOOST_SERIALIZATION_NVP(m_pMinPassThrough); 
+//    ar & BOOST_SERIALIZATION_NVP(m_pOccupancyThreshold);
     std::cout << "**Finished serializing Mapper**\n";
   }
 

--- a/lib/karto_sdk/include/karto_sdk/Mapper.h
+++ b/lib/karto_sdk/include/karto_sdk/Mapper.h
@@ -2357,6 +2357,13 @@ protected:
   // whether to increase the search space if no good matches are initially found
   Parameter<kt_bool> * m_pUseResponseExpansion;
 
+  // Number of beams that must pass through a cell before it will be considered to be occupied 
+  // or unoccupied.  This prevents stray beams from messing up the map. 
+  Parameter<kt_int32u> * m_pMinPassThrough;
+
+  // Minimum ratio of beams hitting cell to beams passing through cell to be marked as occupied
+  Parameter<kt_double> * m_pOccupancyThreshold;
+
   friend class boost::serialization::access;
   template<class Archive>
   void serialize(Archive & ar, const unsigned int version)
@@ -2401,6 +2408,8 @@ protected:
     ar & BOOST_SERIALIZATION_NVP(m_pMinimumAnglePenalty);
     ar & BOOST_SERIALIZATION_NVP(m_pMinimumDistancePenalty);
     ar & BOOST_SERIALIZATION_NVP(m_pUseResponseExpansion);
+    ar & BOOST_SERIALIZATION_NVP(m_pMinPassThrough);
+    ar & BOOST_SERIALIZATION_NVP(m_pOccupancyThreshold);
     std::cout << "**Finished serializing Mapper**\n";
   }
 
@@ -2444,6 +2453,8 @@ public:
   double getParamMinimumAnglePenalty();
   double getParamMinimumDistancePenalty();
   bool getParamUseResponseExpansion();
+  int getParamMinPassThrough();
+  double getParamOccupancyThreshold();
 
   /* Setters */
   // General Parameters
@@ -2482,6 +2493,8 @@ public:
   void setParamMinimumAnglePenalty(double d);
   void setParamMinimumDistancePenalty(double d);
   void setParamUseResponseExpansion(bool b);
+  void setParamMinPassThrough(int i);
+  void setParamOccupancyThreshold(double d);
 };
 BOOST_SERIALIZATION_ASSUME_ABSTRACT(Mapper)
 }  // namespace karto

--- a/lib/karto_sdk/src/Mapper.cpp
+++ b/lib/karto_sdk/src/Mapper.cpp
@@ -2285,12 +2285,24 @@ void Mapper::InitializeParameters()
     "Minimum value of the distance penalty multiplier so scores do not "
     "become too small.",
     0.5, GetParameterManager());
-
+  
   m_pUseResponseExpansion = new Parameter<kt_bool>(
     "UseResponseExpansion",
     "Whether to increase the search space if no good matches are initially "
     "found.",
     false, GetParameterManager());
+
+  m_pMinPassThrough = new Parameter<kt_int32u>(
+    "MinPassThrough",
+    "Number of beams that must pass through a cell before it will be considered to be occupied "
+    "or unoccupied.  This prevents stray beams from messing up the map. "
+    "found.",
+    2, GetParameterManager());
+  
+  m_pOccupancyThreshold = new Parameter<kt_double>(
+    "OccupancyThreshold",
+    "Minimum ratio of beams hitting cell to beams passing through cell to be marked as occupied",
+    0.1, GetParameterManager());
 }
 /* Adding in getters and setters here for easy parameter access */
 
@@ -2447,6 +2459,16 @@ bool Mapper::getParamUseResponseExpansion()
   return static_cast<bool>(m_pUseResponseExpansion->GetValue());
 }
 
+int Mapper::getParamMinPassThrough()
+{
+  return static_cast<int>(m_pMinPassThrough->GetValue());
+}
+
+double Mapper::getParamOccupancyThreshold()
+{
+  return static_cast<double>(m_pOccupancyThreshold->GetValue());
+}
+
 /* Setters for parameters */
 // General Parameters
 void Mapper::setParamUseScanMatching(bool b)
@@ -2597,6 +2619,16 @@ void Mapper::setParamMinimumDistancePenalty(double d)
 void Mapper::setParamUseResponseExpansion(bool b)
 {
   m_pUseResponseExpansion->SetValue((kt_bool)b);
+}
+
+void Mapper::setParamMinPassThrough(int i)
+{
+  m_pMinPassThrough->SetValue((kt_int32u)i);
+}
+
+void Mapper::setParamOccupancyThreshold(double d)
+{
+  m_pOccupancyThreshold->SetValue((kt_double)d);
 }
 
 

--- a/src/merge_maps_kinematic.cpp
+++ b/src/merge_maps_kinematic.cpp
@@ -297,7 +297,7 @@ void MergeMapsKinematic::kartoToROSOccupancyGrid(
 /*****************************************************************************/
 {
   OccupancyGrid * occ_grid = NULL;
-  occ_grid = OccupancyGrid::CreateFromScans(scans, resolution_);
+  occ_grid = OccupancyGrid::CreateFromScans(scans, resolution_, 2, 0.1);
   if (!occ_grid) {
     RCLCPP_INFO(get_logger(),
       "MergeMapsKinematic: Could not make occupancy grid.");

--- a/src/merge_maps_kinematic.cpp
+++ b/src/merge_maps_kinematic.cpp
@@ -35,7 +35,11 @@ void MergeMapsKinematic::configure()
 /*****************************************************************************/
 {
   resolution_ = 0.05;
+  min_pass_through_ = 2;
+  occupancy_threshold_ = 0.1;
   resolution_ = this->declare_parameter("resolution", resolution_);
+  min_pass_through_ = this->declare_parameter("min_pass_through", min_pass_through_);
+  occupancy_threshold_ = this->declare_parameter("occupancy_threshold", occupancy_threshold_);
 
   sstS_.push_back(this->create_publisher<nav_msgs::msg::OccupancyGrid>(
       "/map", rclcpp::QoS(1)));
@@ -297,7 +301,7 @@ void MergeMapsKinematic::kartoToROSOccupancyGrid(
 /*****************************************************************************/
 {
   OccupancyGrid * occ_grid = NULL;
-  occ_grid = OccupancyGrid::CreateFromScans(scans, resolution_, 2, 0.1);
+  occ_grid = OccupancyGrid::CreateFromScans(scans, resolution_, min_pass_through_, occupancy_threshold_);
   if (!occ_grid) {
     RCLCPP_INFO(get_logger(),
       "MergeMapsKinematic: Could not make occupancy grid.");

--- a/src/slam_mapper.cpp
+++ b/src/slam_mapper.cpp
@@ -66,7 +66,7 @@ karto::OccupancyGrid * SMapper::getOccupancyGrid(const double & resolution)
   karto::OccupancyGrid * occ_grid = nullptr;
   return karto::OccupancyGrid::CreateFromScans(
     mapper_->GetAllProcessedScans(),
-    resolution);
+    resolution, (kt_int32u)mapper_->getParamMinPassThrough(), (kt_double)mapper_->getParamOccupancyThreshold());
 }
 
 /*****************************************************************************/
@@ -354,6 +354,21 @@ void SMapper::configure(const rclcpp::Node::SharedPtr & node)
   }
   node->get_parameter("use_response_expansion", use_response_expansion);
   mapper_->setParamUseResponseExpansion(use_response_expansion);
+
+
+  int min_pass_through = 2;
+  if (!node->has_parameter("min_pass_through")) {
+    node->declare_parameter("min_pass_through", min_pass_through);
+  }
+  node->get_parameter("min_pass_through", min_pass_through);
+  mapper_->setParamMinPassThrough(min_pass_through);
+
+  double occupancy_threshold = 0.1;
+  if (!node->has_parameter("occupancy_threshold")) {
+    node->declare_parameter("occupancy_threshold", occupancy_threshold);
+  }
+  node->get_parameter("occupancy_threshold", occupancy_threshold);
+  mapper_->setParamOccupancyThreshold(occupancy_threshold);
 }
 
 /*****************************************************************************/


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Adds missing ros parameters min_pass_through and occupancy_threshold |
| ------ | ----------- |
| Ticket(s) this addresses   | #108 #448 #121 #124 |
| Primary OS tested on | (Ubuntu) |
| Robotic platform tested on | Robotnik RbVogui |

---

## Description of contribution in a few bullet points

* I added the possibility to set the min_pass_through and occupancy_threshold values through ros parameters. These are two variables of the OccupancyGrid class
* I modified the inputs of the static CreateFromScans method to allow the two variables to be passed
* To set the parameters from the slam toolbox node I added the two variables to the Mapper class


## Description of documentation updates required from your changes

* The default ROS config and documentation page must be modified to include also these two parameters

---

## Future work that may be required in bullet points

* Create a guide for tuning the two parameters
* Tests on use cases