### PR TITLE
Switch from deprecated rmw_qos_profile_t to rclcpp::QoS

### DIFF
--- a/src/slam_toolbox_common.cpp
+++ b/src/slam_toolbox_common.cpp
@@ -21,6 +21,7 @@
 #include <string>
 #include <chrono>
 #include "slam_toolbox/slam_toolbox_common.hpp"
+#include "rclcpp/rclcpp/qos.hpp"
 #include "slam_toolbox/serialization.hpp"
 
 namespace slam_toolbox
@@ -456,7 +457,7 @@ void SlamToolbox::setROSInterfaces()
   scan_filter_sub_ =
     std::make_unique<message_filters::Subscriber<sensor_msgs::msg::LaserScan,
       rclcpp_lifecycle::LifecycleNode>>(
-    shared_from_this().get(), scan_topic_, rmw_qos_profile_sensor_data);
+    shared_from_this().get(), scan_topic_, rclcpp::SensorDataQoS());
   scan_filter_ =
     std::make_unique<tf2_ros::MessageFilter<sensor_msgs::msg::LaserScan>>(
     *scan_filter_sub_, *tf_, odom_frame_, scan_queue_size_,


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | - |
| Primary OS tested on | Ubuntu 24.04 |
| Robotic platform tested on | Research electric vehicle @ USyd |

---

## Description of contribution in a few bullet points

`rmw_qos_profile_t` is deprecated. Recent rolling sync with this change seemed to make even `sensor_data_qos` subscribe as `RELIABLE`. Switching to `rclcpp::QoS` fixes both problems.

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->
