### PR TITLE
fixed install command typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ rosdep install -q -y -r --from-paths src --ignore-src
 Or install via apt
 
 ```
-apt install ros-eloquent-slam-toolbox
+apt install ros-jazzy-slam-toolbox
 ```
 
 Run your colcon build procedure of choice.


### PR DESCRIPTION
---
## Description of contribution in a few bullet points

-  I fixed a typo in the install command. Changed 'eloquent' to 'jazzy'.