### PR TITLE
slam_toolbox_async_node is now pausable [jazzy]

### DIFF
--- a/src/slam_toolbox_async.cpp
+++ b/src/slam_toolbox_async.cpp
@@ -53,7 +53,10 @@ void AsynchronousSlamToolbox::laserCallback(
     return;
   }
 
-  addScan(laser, scan, pose);
+  // if not paused, process scan
+  if (shouldProcessScan(scan, pose)) {
+    addScan(laser, scan, pose);
+  }
 }
 
 /*****************************************************************************/


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #745  |
| Primary OS tested on | Ubuntu 24.04 |
| Robotic platform tested on | Custom robot, both in Gazebo and real setup |

---

## Description of contribution in a few bullet points

* `slam_toolbox_async_node` is now pausable, in the same way as `slam_toolbox_sync_node` is 

## Description of documentation updates required from your changes

None

---
