### PR TITLE
slam_toolbox_async_node is now pauseable [noetic]

### DIFF
--- a/slam_toolbox/src/slam_toolbox_async.cpp
+++ b/slam_toolbox/src/slam_toolbox_async.cpp
@@ -52,7 +52,12 @@ void AsynchronousSlamToolbox::laserCallback(
     return;
   }
 
-  addScan(laser, scan, pose);
+  // if not paused, process scan
+  if (shouldProcessScan(scan, pose))
+  {
+    addScan(laser, scan, pose);
+  }
+
   return;
 }
 


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #745  |
| Primary OS tested on | Ubuntu 20.04 |
| Robotic platform tested on | Custom robot, both in Gazebo and real setup |

---

## Description of contribution in a few bullet points

* `slam_toolbox_async_node` is now pausable, in the same way as `slam_toolbox_sync_node` is 

## Description of documentation updates required from your changes

None

---
