### PR TITLE
Expose Multiscan Matching Coarse Fine Resolution Multiplier

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,11 +304,15 @@ The following settings and options are exposed to you. My default configuration 
 
 `correlation_search_space_smear_deviation` - Amount of multimodal smearing to smooth out responses
 
+`correlation_search_space_coarse_resolution_multiplier` - Multiplier applied to the fine scan search translational resolution to get the coarse search resolution
+
 `loop_search_space_dimension` - Size of the search grid over the loop closure algorithm
 
 `loop_search_space_resolution` - Search grid resolution to do loop closure over
 
 `loop_search_space_smear_deviation` - Amount of multimodal smearing to smooth out responses
+
+`loop_search_space_coarse_resolution_multiplier` - Multiplier applied to the fine scan search translational resolution to get the coarse search resolution
 
 `distance_variance_penalty` - A penalty to apply to a matched scan as it differs from the odometric pose
 

--- a/config/mapper_params_lifelong.yaml
+++ b/config/mapper_params_lifelong.yaml
@@ -68,12 +68,14 @@ slam_toolbox:
     # Correlation Parameters - Correlation Parameters
     correlation_search_space_dimension: 0.5
     correlation_search_space_resolution: 0.01
-    correlation_search_space_smear_deviation: 0.1 
+    correlation_search_space_smear_deviation: 0.1
+    correlation_search_space_coarse_resolution_multiplier: 10
 
     # Correlation Parameters - Loop Closure Parameters
     loop_search_space_dimension: 8.0
     loop_search_space_resolution: 0.05
     loop_search_space_smear_deviation: 0.03
+    loop_search_space_coarse_resolution_multiplier: 10
 
     # Scan Matcher Parameters
     distance_variance_penalty: 0.5      

--- a/config/mapper_params_lifelong.yaml
+++ b/config/mapper_params_lifelong.yaml
@@ -69,13 +69,13 @@ slam_toolbox:
     correlation_search_space_dimension: 0.5
     correlation_search_space_resolution: 0.01
     correlation_search_space_smear_deviation: 0.1
-    correlation_search_space_coarse_resolution_multiplier: 10
+    correlation_search_space_coarse_resolution_multiplier: 2
 
     # Correlation Parameters - Loop Closure Parameters
     loop_search_space_dimension: 8.0
     loop_search_space_resolution: 0.05
     loop_search_space_smear_deviation: 0.03
-    loop_search_space_coarse_resolution_multiplier: 10
+    loop_search_space_coarse_resolution_multiplier: 2
 
     # Scan Matcher Parameters
     distance_variance_penalty: 0.5      

--- a/config/mapper_params_localization.yaml
+++ b/config/mapper_params_localization.yaml
@@ -51,13 +51,13 @@ slam_toolbox:
     correlation_search_space_dimension: 0.5
     correlation_search_space_resolution: 0.01
     correlation_search_space_smear_deviation: 0.1
-    correlation_search_space_coarse_resolution_multiplier: 10
+    correlation_search_space_coarse_resolution_multiplier: 2
 
     # Correlation Parameters - Loop Closure Parameters
     loop_search_space_dimension: 8.0
     loop_search_space_resolution: 0.05
     loop_search_space_smear_deviation: 0.03
-    loop_search_space_coarse_resolution_multiplier: 10
+    loop_search_space_coarse_resolution_multiplier: 2
     loop_search_maximum_distance: 3.0
 
     # Scan Matcher Parameters

--- a/config/mapper_params_localization.yaml
+++ b/config/mapper_params_localization.yaml
@@ -50,12 +50,14 @@ slam_toolbox:
     # Correlation Parameters - Correlation Parameters
     correlation_search_space_dimension: 0.5
     correlation_search_space_resolution: 0.01
-    correlation_search_space_smear_deviation: 0.1 
+    correlation_search_space_smear_deviation: 0.1
+    correlation_search_space_coarse_resolution_multiplier: 10
 
     # Correlation Parameters - Loop Closure Parameters
     loop_search_space_dimension: 8.0
     loop_search_space_resolution: 0.05
     loop_search_space_smear_deviation: 0.03
+    loop_search_space_coarse_resolution_multiplier: 10
     loop_search_maximum_distance: 3.0
 
     # Scan Matcher Parameters

--- a/config/mapper_params_offline.yaml
+++ b/config/mapper_params_offline.yaml
@@ -51,13 +51,13 @@ slam_toolbox:
     correlation_search_space_dimension: 0.5
     correlation_search_space_resolution: 0.01
     correlation_search_space_smear_deviation: 0.1
-    correlation_search_space_coarse_resolution_multiplier: 10
+    correlation_search_space_coarse_resolution_multiplier: 2
 
     # Correlation Parameters - Loop Closure Parameters
     loop_search_space_dimension: 8.0
     loop_search_space_resolution: 0.05
     loop_search_space_smear_deviation: 0.03
-    loop_search_space_coarse_resolution_multiplier: 10
+    loop_search_space_coarse_resolution_multiplier: 2
 
     # Scan Matcher Parameters
     distance_variance_penalty: 0.5      

--- a/config/mapper_params_offline.yaml
+++ b/config/mapper_params_offline.yaml
@@ -50,12 +50,14 @@ slam_toolbox:
     # Correlation Parameters - Correlation Parameters
     correlation_search_space_dimension: 0.5
     correlation_search_space_resolution: 0.01
-    correlation_search_space_smear_deviation: 0.1 
+    correlation_search_space_smear_deviation: 0.1
+    correlation_search_space_coarse_resolution_multiplier: 10
 
     # Correlation Parameters - Loop Closure Parameters
     loop_search_space_dimension: 8.0
     loop_search_space_resolution: 0.05
     loop_search_space_smear_deviation: 0.03
+    loop_search_space_coarse_resolution_multiplier: 10
 
     # Scan Matcher Parameters
     distance_variance_penalty: 0.5      

--- a/config/mapper_params_online_async.yaml
+++ b/config/mapper_params_online_async.yaml
@@ -59,13 +59,13 @@ slam_toolbox:
     correlation_search_space_dimension: 0.5
     correlation_search_space_resolution: 0.01
     correlation_search_space_smear_deviation: 0.1
-    correlation_search_space_coarse_resolution_multiplier: 10
+    correlation_search_space_coarse_resolution_multiplier: 2
 
     # Correlation Parameters - Loop Closure Parameters
     loop_search_space_dimension: 8.0
     loop_search_space_resolution: 0.05
     loop_search_space_smear_deviation: 0.03
-    loop_search_space_coarse_resolution_multiplier: 10
+    loop_search_space_coarse_resolution_multiplier: 2
 
     # Scan Matcher Parameters
     distance_variance_penalty: 0.5      

--- a/config/mapper_params_online_async.yaml
+++ b/config/mapper_params_online_async.yaml
@@ -58,12 +58,14 @@ slam_toolbox:
     # Correlation Parameters - Correlation Parameters
     correlation_search_space_dimension: 0.5
     correlation_search_space_resolution: 0.01
-    correlation_search_space_smear_deviation: 0.1 
+    correlation_search_space_smear_deviation: 0.1
+    correlation_search_space_coarse_resolution_multiplier: 10
 
     # Correlation Parameters - Loop Closure Parameters
     loop_search_space_dimension: 8.0
     loop_search_space_resolution: 0.05
     loop_search_space_smear_deviation: 0.03
+    loop_search_space_coarse_resolution_multiplier: 10
 
     # Scan Matcher Parameters
     distance_variance_penalty: 0.5      

--- a/config/mapper_params_online_sync.yaml
+++ b/config/mapper_params_online_sync.yaml
@@ -59,13 +59,13 @@ slam_toolbox:
     correlation_search_space_dimension: 0.5
     correlation_search_space_resolution: 0.01
     correlation_search_space_smear_deviation: 0.1
-    correlation_search_space_coarse_resolution_multiplier: 10
+    correlation_search_space_coarse_resolution_multiplier: 2
 
     # Correlation Parameters - Loop Closure Parameters
     loop_search_space_dimension: 8.0
     loop_search_space_resolution: 0.05
     loop_search_space_smear_deviation: 0.03
-    loop_search_space_coarse_resolution_multiplier: 10
+    loop_search_space_coarse_resolution_multiplier: 2
 
     # Scan Matcher Parameters
     distance_variance_penalty: 0.5      

--- a/config/mapper_params_online_sync.yaml
+++ b/config/mapper_params_online_sync.yaml
@@ -58,12 +58,14 @@ slam_toolbox:
     # Correlation Parameters - Correlation Parameters
     correlation_search_space_dimension: 0.5
     correlation_search_space_resolution: 0.01
-    correlation_search_space_smear_deviation: 0.1 
+    correlation_search_space_smear_deviation: 0.1
+    correlation_search_space_coarse_resolution_multiplier: 10
 
     # Correlation Parameters - Loop Closure Parameters
     loop_search_space_dimension: 8.0
     loop_search_space_resolution: 0.05
     loop_search_space_smear_deviation: 0.03
+    loop_search_space_coarse_resolution_multiplier: 10
 
     # Scan Matcher Parameters
     distance_variance_penalty: 0.5      

--- a/lib/karto_sdk/include/karto_sdk/Mapper.h
+++ b/lib/karto_sdk/include/karto_sdk/Mapper.h
@@ -2316,7 +2316,7 @@ protected:
 
   /**
    * The multiplier applied to the fine scan search translational resolution to get the coarse search resolution.
-   * The default value is 10.
+   * The default value is 2.
    */
   Parameter<kt_int32u> * m_pCorrelationSearchSpaceCoarseResolutionMultiplier;
 
@@ -2343,7 +2343,7 @@ protected:
 
   /**
    * The multiplier applied to the fine scan search translational resolution to get the coarse search resolution.
-   * The default value is 10.
+   * The default value is 2.
    */
   Parameter<kt_int32u> * m_pLoopSearchSpaceCoarseResolutionMultiplier;
 

--- a/lib/karto_sdk/include/karto_sdk/Mapper.h
+++ b/lib/karto_sdk/include/karto_sdk/Mapper.h
@@ -2357,7 +2357,7 @@ protected:
   Parameter<kt_double> * m_pAngleVariancePenalty;
 
   // The range of angles to search during a coarse search and a finer search
-  Parameter<kt_double> * m_pFineSearchAngleResolution;
+  Parameter<kt_double> * m_pFineSearchAngleOffset;
   Parameter<kt_double> * m_pCoarseSearchAngleOffset;
 
   // Resolution of angles to search during a coarse search
@@ -2416,7 +2416,7 @@ protected:
     ar & BOOST_SERIALIZATION_NVP(m_pLoopSearchSpaceSmearDeviation);
     ar & BOOST_SERIALIZATION_NVP(m_pDistanceVariancePenalty);
     ar & BOOST_SERIALIZATION_NVP(m_pAngleVariancePenalty);
-    ar & BOOST_SERIALIZATION_NVP(m_pFineSearchAngleResolution);
+    ar & BOOST_SERIALIZATION_NVP(m_pFineSearchAngleOffset);
     ar & BOOST_SERIALIZATION_NVP(m_pCoarseSearchAngleOffset);
     ar & BOOST_SERIALIZATION_NVP(m_pCoarseAngleResolution);
     ar & BOOST_SERIALIZATION_NVP(m_pMinimumAnglePenalty);

--- a/lib/karto_sdk/include/karto_sdk/Mapper.h
+++ b/lib/karto_sdk/include/karto_sdk/Mapper.h
@@ -1344,6 +1344,7 @@ public:
     kt_double searchSize,
     kt_double resolution,
     kt_double smearDeviation,
+    kt_int32u resolutionMultiplier,
     kt_double rangeThreshold);
 
   /**
@@ -1498,6 +1499,7 @@ private:
   std::vector<kt_double> m_yPoses;
   Pose2 m_rSearchCenter;
   kt_double m_searchAngleOffset;
+  kt_int32u m_nResolutionMultiplier;
   kt_int32u m_nAngles;
   kt_double m_searchAngleResolution;
   kt_bool m_doPenalize;
@@ -1520,6 +1522,7 @@ private:
     ar & BOOST_SERIALIZATION_NVP(m_nAngles);
     ar & BOOST_SERIALIZATION_NVP(m_searchAngleResolution);
     ar & BOOST_SERIALIZATION_NVP(m_doPenalize);
+    // ar & BOOST_SERIALIZATION_NVP(m_nResolutionMultiplier);
 
     // Note - m_pPoseResponse is generally only ever defined within the
     // execution of ScanMatcher::CorrelateScan and used as a temporary
@@ -2311,6 +2314,11 @@ protected:
    */
   Parameter<kt_double> * m_pCorrelationSearchSpaceSmearDeviation;
 
+  /**
+   * The multiplier applied to the fine scan search translational resolution to get the coarse search resolution.
+   * The default value is 10.
+   */
+  Parameter<kt_int32u> * m_pCorrelationSearchSpaceCoarseResolutionMultiplier;
 
   //////////////////////////////////////////////////////////////////////////////
   //    CorrelationParameters loopCorrelationParameters;
@@ -2333,6 +2341,12 @@ protected:
    */
   Parameter<kt_double> * m_pLoopSearchSpaceSmearDeviation;
 
+  /**
+   * The multiplier applied to the fine scan search translational resolution to get the coarse search resolution.
+   * The default value is 10.
+   */
+  Parameter<kt_int32u> * m_pLoopSearchSpaceCoarseResolutionMultiplier;
+
   //////////////////////////////////////////////////////////////////////////////
   // ScanMatcherParameters;
 
@@ -2343,7 +2357,7 @@ protected:
   Parameter<kt_double> * m_pAngleVariancePenalty;
 
   // The range of angles to search during a coarse search and a finer search
-  Parameter<kt_double> * m_pFineSearchAngleOffset;
+  Parameter<kt_double> * m_pFineSearchAngleResolution;
   Parameter<kt_double> * m_pCoarseSearchAngleOffset;
 
   // Resolution of angles to search during a coarse search
@@ -2402,13 +2416,15 @@ protected:
     ar & BOOST_SERIALIZATION_NVP(m_pLoopSearchSpaceSmearDeviation);
     ar & BOOST_SERIALIZATION_NVP(m_pDistanceVariancePenalty);
     ar & BOOST_SERIALIZATION_NVP(m_pAngleVariancePenalty);
-    ar & BOOST_SERIALIZATION_NVP(m_pFineSearchAngleOffset);
+    ar & BOOST_SERIALIZATION_NVP(m_pFineSearchAngleResolution);
     ar & BOOST_SERIALIZATION_NVP(m_pCoarseSearchAngleOffset);
     ar & BOOST_SERIALIZATION_NVP(m_pCoarseAngleResolution);
     ar & BOOST_SERIALIZATION_NVP(m_pMinimumAnglePenalty);
     ar & BOOST_SERIALIZATION_NVP(m_pMinimumDistancePenalty);
     ar & BOOST_SERIALIZATION_NVP(m_pUseResponseExpansion);
-// NOTE: the following two lines are commented out to avoid breaking the serialization of already existing maps
+// NOTE: the following four lines are commented out to avoid breaking the serialization of already existing maps
+//    ar & BOOST_SERIALIZATION_NVP(m_pCorrelationSearchSpaceCoarseResolutionMultiplier);
+//    ar & BOOST_SERIALIZATION_NVP(m_pLoopSearchSpaceCoarseResolutionMultiplier);
 //    ar & BOOST_SERIALIZATION_NVP(m_pMinPassThrough); 
 //    ar & BOOST_SERIALIZATION_NVP(m_pOccupancyThreshold);
     std::cout << "**Finished serializing Mapper**\n";
@@ -2440,11 +2456,13 @@ public:
   double getParamCorrelationSearchSpaceDimension();
   double getParamCorrelationSearchSpaceResolution();
   double getParamCorrelationSearchSpaceSmearDeviation();
+  int getParamCorrelationSearchSpaceCoarseResolutionMultiplier();
 
   // Correlation Parameters - Loop Closure Parameters
   double getParamLoopSearchSpaceDimension();
   double getParamLoopSearchSpaceResolution();
   double getParamLoopSearchSpaceSmearDeviation();
+  int getParamLoopSearchSpaceCoarseResolutionMultiplier();
 
   // Scan Matcher Parameters
   double getParamDistanceVariancePenalty();
@@ -2480,11 +2498,13 @@ public:
   void setParamCorrelationSearchSpaceDimension(double d);
   void setParamCorrelationSearchSpaceResolution(double d);
   void setParamCorrelationSearchSpaceSmearDeviation(double d);
+  void setParamCorrelationSearchSpaceCoarseResolutionMultiplier(int i);
 
   // Correlation Parameters - Loop Closure Parameters
   void setParamLoopSearchSpaceDimension(double d);
   void setParamLoopSearchSpaceResolution(double d);
   void setParamLoopSearchSpaceSmearDeviation(double d);
+  void setParamLoopSearchSpaceCoarseResolutionMultiplier(int i);
 
   // Scan Matcher Parameters
   void setParamDistanceVariancePenalty(double d);

--- a/lib/karto_sdk/include/karto_sdk/Math.h
+++ b/lib/karto_sdk/include/karto_sdk/Math.h
@@ -90,6 +90,16 @@ inline kt_double Round(kt_double value)
 }
 
 /**
+ * Floor function
+ * @param value
+ * @return floors value to the nearest whole number (as double)
+ */
+inline kt_double Floor(kt_double value)
+{
+  return floor(value);
+}
+
+/**
  * Binary minimum function
  * @param value1
  * @param value2

--- a/lib/karto_sdk/src/Mapper.cpp
+++ b/lib/karto_sdk/src/Mapper.cpp
@@ -2257,7 +2257,7 @@ void Mapper::InitializeParameters()
     "CorrelationSearchSpaceCoarseResolutionMultiplier",
     "The multiplier applied to the fine scan search translational resolution "
     "to get the coarse search resolution",
-    10, GetParameterManager());
+    2, GetParameterManager());
 
   //////////////////////////////////////////////////////////////////////////////
   //    CorrelationParameters loopCorrelationParameters;
@@ -2282,7 +2282,7 @@ void Mapper::InitializeParameters()
     "LoopSearchSpaceCoarseResolutionMultiplier",
     "The multiplier applied to the fine scan search translational resolution "
     "to get the coarse search resolution",
-    10, GetParameterManager());
+    2, GetParameterManager());
 
   //////////////////////////////////////////////////////////////////////////////
   // ScanMatcherParameters;

--- a/lib/karto_sdk/src/Mapper.cpp
+++ b/lib/karto_sdk/src/Mapper.cpp
@@ -957,8 +957,6 @@ void ScanMatcher::ComputePositionalCovariance(
     }
   }
 
-
-
   if (norm > KT_TOLERANCE) {
     kt_double varianceXX = accumulatedVarianceXX / norm;
     kt_double varianceXY = accumulatedVarianceXY / norm;

--- a/lib/karto_sdk/src/Mapper.cpp
+++ b/lib/karto_sdk/src/Mapper.cpp
@@ -629,7 +629,7 @@ kt_double ScanMatcher::MatchScan(
       m_pCorrelationGrid->GetResolution());
     bestResponse = CorrelateScan(pScan, rMean, fineSearchOffset, fineSearchResolution,
         0.5 * m_pMapper->m_pCoarseAngleResolution->GetValue(),
-        m_pMapper->m_pFineSearchAngleResolution->GetValue(),
+        m_pMapper->m_pFineSearchAngleOffset->GetValue(),
         doPenalize, rMean, rCovariance, true);
   }
 
@@ -939,7 +939,7 @@ void ScanMatcher::ComputePositionalCovariance(
   assert(math::DoubleEqual(startY + (nY - 1) * rSearchSpaceResolution.GetY(), -startY));
 
   for (kt_double y: yPoses) {
-    
+
     for (kt_double x: xPoses) {
 
       Vector2<kt_int32s> gridPoint =
@@ -2301,7 +2301,7 @@ void Mapper::InitializeParameters()
     "See DistanceVariancePenalty.",
     math::Square(math::DegreesToRadians(20)), GetParameterManager());
 
-  m_pFineSearchAngleResolution = new Parameter<kt_double>(
+  m_pFineSearchAngleOffset = new Parameter<kt_double>(
     "FineSearchAngleOffset",
     "The range of angles to search during a fine search.",
     math::DegreesToRadians(0.2), GetParameterManager());
@@ -2488,7 +2488,7 @@ double Mapper::getParamAngleVariancePenalty()
 
 double Mapper::getParamFineSearchAngleOffset()
 {
-  return static_cast<double>(m_pFineSearchAngleResolution->GetValue());
+  return static_cast<double>(m_pFineSearchAngleOffset->GetValue());
 }
 
 double Mapper::getParamCoarseSearchAngleOffset()
@@ -2658,7 +2658,7 @@ void Mapper::setParamAngleVariancePenalty(double d)
 
 void Mapper::setParamFineSearchAngleOffset(double d)
 {
-  m_pFineSearchAngleResolution->SetValue((kt_double)d);
+  m_pFineSearchAngleOffset->SetValue((kt_double)d);
 }
 
 void Mapper::setParamCoarseSearchAngleOffset(double d)

--- a/lib/karto_sdk/src/Mapper.cpp
+++ b/lib/karto_sdk/src/Mapper.cpp
@@ -476,7 +476,7 @@ ScanMatcher::~ScanMatcher()
 
 ScanMatcher * ScanMatcher::Create(
   Mapper * pMapper, kt_double searchSize, kt_double resolution,
-  kt_double smearDeviation, kt_double rangeThreshold)
+  kt_double smearDeviation, kt_int32u resolutionMultiplier, kt_double rangeThreshold)
 {
   // invalid parameters
   if (resolution <= 0) {
@@ -489,6 +489,9 @@ ScanMatcher * ScanMatcher::Create(
     return NULL;
   }
   if (rangeThreshold <= 0) {
+    return NULL;
+  }
+  if (resolutionMultiplier < 1) {
     return NULL;
   }
 
@@ -517,6 +520,7 @@ ScanMatcher * ScanMatcher::Create(
   pScanMatcher->m_pCorrelationGrid = pCorrelationGrid;
   pScanMatcher->m_pSearchSpaceProbs = pSearchSpaceProbs;
   pScanMatcher->m_pGridLookup = new GridIndexLookup<kt_int8u>(pCorrelationGrid);
+  pScanMatcher->m_nResolutionMultiplier = resolutionMultiplier;
 
   return pScanMatcher;
 }
@@ -581,8 +585,9 @@ kt_double ScanMatcher::MatchScan(
     0.5 * (searchDimensions.GetY() - 1) * m_pCorrelationGrid->GetResolution());
 
   // a coarse search only checks half the cells in each dimension
-  Vector2<kt_double> coarseSearchResolution(2 * m_pCorrelationGrid->GetResolution(),
-    2 * m_pCorrelationGrid->GetResolution());
+  Vector2<kt_double> coarseSearchResolution(
+    m_nResolutionMultiplier * m_pCorrelationGrid->GetResolution(),
+    m_nResolutionMultiplier * m_pCorrelationGrid->GetResolution());
 
   // actual scan-matching
   kt_double bestResponse = CorrelateScan(pScan, scanPose, coarseSearchOffset,
@@ -624,7 +629,7 @@ kt_double ScanMatcher::MatchScan(
       m_pCorrelationGrid->GetResolution());
     bestResponse = CorrelateScan(pScan, rMean, fineSearchOffset, fineSearchResolution,
         0.5 * m_pMapper->m_pCoarseAngleResolution->GetValue(),
-        m_pMapper->m_pFineSearchAngleOffset->GetValue(),
+        m_pMapper->m_pFineSearchAngleResolution->GetValue(),
         doPenalize, rMean, rCovariance, true);
   }
 
@@ -734,20 +739,26 @@ kt_double ScanMatcher::CorrelateScan(
   // calculate position arrays
 
   m_xPoses.clear();
-  kt_int32u nX = static_cast<kt_int32u>(math::Round(rSearchSpaceOffset.GetX() *
-    2.0 / rSearchSpaceResolution.GetX()) + 1);
+  kt_double nXSteps = rSearchSpaceOffset.GetX() * 2.0 / rSearchSpaceResolution.GetX();
+  kt_int32u nX = static_cast<kt_int32u>(math::Floor(nXSteps) + 1);
   kt_double startX = -rSearchSpaceOffset.GetX();
   for (kt_int32u xIndex = 0; xIndex < nX; xIndex++) {
     m_xPoses.push_back(startX + xIndex * rSearchSpaceResolution.GetX());
   }
+  if (nXSteps - math::Floor(nXSteps) >= 0.5) {
+    m_xPoses.push_back(-startX);
+  }
   assert(math::DoubleEqual(m_xPoses.back(), -startX));
 
   m_yPoses.clear();
-  kt_int32u nY = static_cast<kt_int32u>(math::Round(rSearchSpaceOffset.GetY() *
-    2.0 / rSearchSpaceResolution.GetY()) + 1);
+  kt_double nYSteps = rSearchSpaceOffset.GetY() * 2.0 / rSearchSpaceResolution.GetY();
+  kt_int32u nY = static_cast<kt_int32u>(math::Floor(nYSteps) + 1);
   kt_double startY = -rSearchSpaceOffset.GetY();
   for (kt_int32u yIndex = 0; yIndex < nY; yIndex++) {
     m_yPoses.push_back(startY + yIndex * rSearchSpaceResolution.GetY());
+  }
+  if (nYSteps - math::Floor(nYSteps) >= 0.5) {
+    m_yPoses.push_back(-startY);
   }
   assert(math::DoubleEqual(m_yPoses.back(), -startY));
 
@@ -901,21 +912,35 @@ void ScanMatcher::ComputePositionalCovariance(
   kt_double offsetX = rSearchSpaceOffset.GetX();
   kt_double offsetY = rSearchSpaceOffset.GetY();
 
+  std::vector<kt_double> xPoses;
+  kt_double nXSteps = offsetX * 2.0 / rSearchSpaceResolution.GetX();
   kt_int32u nX =
-    static_cast<kt_int32u>(math::Round(offsetX * 2.0 / rSearchSpaceResolution.GetX()) + 1);
+    static_cast<kt_int32u>(math::Floor(nXSteps) + 1);
   kt_double startX = -offsetX;
+  for (kt_int32u xIndex = 0; xIndex < nX; xIndex++) {
+    xPoses.push_back(startX + xIndex * rSearchSpaceResolution.GetX());
+  }
+  if (nXSteps - math::Floor(nXSteps) >= 0.5) {
+    xPoses.push_back(-startX);
+  }
   assert(math::DoubleEqual(startX + (nX - 1) * rSearchSpaceResolution.GetX(), -startX));
 
+  std::vector<kt_double> yPoses;
+  kt_double nYSteps = offsetY * 2.0 / rSearchSpaceResolution.GetY();
   kt_int32u nY =
-    static_cast<kt_int32u>(math::Round(offsetY * 2.0 / rSearchSpaceResolution.GetY()) + 1);
+    static_cast<kt_int32u>(math::Floor(nYSteps) + 1);
   kt_double startY = -offsetY;
+  for (kt_int32u yIndex = 0; yIndex < nY; yIndex++) {
+    yPoses.push_back(startY + yIndex * rSearchSpaceResolution.GetY());
+  }
+  if (nYSteps - math::Floor(nYSteps) >= 0.5) {
+    yPoses.push_back(-startY);
+  }
   assert(math::DoubleEqual(startY + (nY - 1) * rSearchSpaceResolution.GetY(), -startY));
 
-  for (kt_int32u yIndex = 0; yIndex < nY; yIndex++) {
-    kt_double y = startY + yIndex * rSearchSpaceResolution.GetY();
-
-    for (kt_int32u xIndex = 0; xIndex < nX; xIndex++) {
-      kt_double x = startX + xIndex * rSearchSpaceResolution.GetX();
+  for (kt_double y: yPoses) {
+    
+    for (kt_double x: xPoses) {
 
       Vector2<kt_int32s> gridPoint =
         m_pSearchSpaceProbs->WorldToGrid(Vector2<kt_double>(rSearchCenter.GetX() + x,
@@ -931,6 +956,8 @@ void ScanMatcher::ComputePositionalCovariance(
       }
     }
   }
+
+
 
   if (norm > KT_TOLERANCE) {
     kt_double varianceXX = accumulatedVarianceXX / norm;
@@ -1397,7 +1424,9 @@ MapperGraph::MapperGraph(Mapper * pMapper, kt_double rangeThreshold)
   m_pLoopScanMatcher = ScanMatcher::Create(pMapper,
     m_pMapper->m_pLoopSearchSpaceDimension->GetValue(),
     m_pMapper->m_pLoopSearchSpaceResolution->GetValue(),
-    m_pMapper->m_pLoopSearchSpaceSmearDeviation->GetValue(), rangeThreshold);
+    m_pMapper->m_pLoopSearchSpaceSmearDeviation->GetValue(),
+    m_pMapper->m_pCorrelationSearchSpaceCoarseResolutionMultiplier->GetValue(),
+    rangeThreshold);
   assert(m_pLoopScanMatcher);
 
   m_pTraversal = new BreadthFirstTraversal<LocalizedRangeScan>(this);
@@ -2037,7 +2066,9 @@ void MapperGraph::UpdateLoopScanMatcher(kt_double rangeThreshold)
   m_pLoopScanMatcher = ScanMatcher::Create(m_pMapper,
     m_pMapper->m_pLoopSearchSpaceDimension->GetValue(),
     m_pMapper->m_pLoopSearchSpaceResolution->GetValue(),
-    m_pMapper->m_pLoopSearchSpaceSmearDeviation->GetValue(), rangeThreshold);
+    m_pMapper->m_pLoopSearchSpaceSmearDeviation->GetValue(),
+    m_pMapper->m_pCorrelationSearchSpaceCoarseResolutionMultiplier->GetValue(),
+    rangeThreshold);
   assert(m_pLoopScanMatcher);
 }
 
@@ -2224,6 +2255,11 @@ void Mapper::InitializeParameters()
     "smoother response.",
     0.03, GetParameterManager());
 
+  m_pCorrelationSearchSpaceCoarseResolutionMultiplier = new Parameter<kt_int32u>(
+    "CorrelationSearchSpaceCoarseResolutionMultiplier",
+    "The multiplier applied to the fine scan search translational resolution "
+    "to get the coarse search resolution",
+    10, GetParameterManager());
 
   //////////////////////////////////////////////////////////////////////////////
   //    CorrelationParameters loopCorrelationParameters;
@@ -2244,6 +2280,12 @@ void Mapper::InitializeParameters()
     "smoother response.",
     0.03, GetParameterManager());
 
+  m_pLoopSearchSpaceCoarseResolutionMultiplier = new Parameter<kt_int32u>(
+    "LoopSearchSpaceCoarseResolutionMultiplier",
+    "The multiplier applied to the fine scan search translational resolution "
+    "to get the coarse search resolution",
+    10, GetParameterManager());
+
   //////////////////////////////////////////////////////////////////////////////
   // ScanMatcherParameters;
 
@@ -2259,7 +2301,7 @@ void Mapper::InitializeParameters()
     "See DistanceVariancePenalty.",
     math::Square(math::DegreesToRadians(20)), GetParameterManager());
 
-  m_pFineSearchAngleOffset = new Parameter<kt_double>(
+  m_pFineSearchAngleResolution = new Parameter<kt_double>(
     "FineSearchAngleOffset",
     "The range of angles to search during a fine search.",
     math::DegreesToRadians(0.2), GetParameterManager());
@@ -2405,6 +2447,11 @@ double Mapper::getParamCorrelationSearchSpaceSmearDeviation()
   return static_cast<double>(m_pCorrelationSearchSpaceSmearDeviation->GetValue());
 }
 
+int Mapper::getParamCorrelationSearchSpaceCoarseResolutionMultiplier()
+{
+  return static_cast<int>(m_pCorrelationSearchSpaceCoarseResolutionMultiplier->GetValue());
+}
+
 // Correlation Parameters - Loop Correlation Parameters
 
 double Mapper::getParamLoopSearchSpaceDimension()
@@ -2422,6 +2469,11 @@ double Mapper::getParamLoopSearchSpaceSmearDeviation()
   return static_cast<double>(m_pLoopSearchSpaceSmearDeviation->GetValue());
 }
 
+int Mapper::getParamLoopSearchSpaceCoarseResolutionMultiplier()
+{
+  return static_cast<int>(m_pLoopSearchSpaceCoarseResolutionMultiplier->GetValue());
+}
+
 // ScanMatcher Parameters
 
 double Mapper::getParamDistanceVariancePenalty()
@@ -2436,7 +2488,7 @@ double Mapper::getParamAngleVariancePenalty()
 
 double Mapper::getParamFineSearchAngleOffset()
 {
-  return static_cast<double>(m_pFineSearchAngleOffset->GetValue());
+  return static_cast<double>(m_pFineSearchAngleResolution->GetValue());
 }
 
 double Mapper::getParamCoarseSearchAngleOffset()
@@ -2567,6 +2619,10 @@ void Mapper::setParamCorrelationSearchSpaceSmearDeviation(double d)
   m_pCorrelationSearchSpaceSmearDeviation->SetValue((kt_double)d);
 }
 
+void Mapper::setParamCorrelationSearchSpaceCoarseResolutionMultiplier(int i)
+{
+  m_pCorrelationSearchSpaceCoarseResolutionMultiplier->SetValue((kt_int32u)i);
+}
 
 // Correlation Parameters - Loop Closure Parameters
 void Mapper::setParamLoopSearchSpaceDimension(double d)
@@ -2584,6 +2640,10 @@ void Mapper::setParamLoopSearchSpaceSmearDeviation(double d)
   m_pLoopSearchSpaceSmearDeviation->SetValue((kt_double)d);
 }
 
+void Mapper::setParamLoopSearchSpaceCoarseResolutionMultiplier(int i)
+{
+  m_pLoopSearchSpaceCoarseResolutionMultiplier->SetValue((kt_int32u)i);
+}
 
 // Scan Matcher Parameters
 void Mapper::setParamDistanceVariancePenalty(double d)
@@ -2598,7 +2658,7 @@ void Mapper::setParamAngleVariancePenalty(double d)
 
 void Mapper::setParamFineSearchAngleOffset(double d)
 {
-  m_pFineSearchAngleOffset->SetValue((kt_double)d);
+  m_pFineSearchAngleResolution->SetValue((kt_double)d);
 }
 
 void Mapper::setParamCoarseSearchAngleOffset(double d)
@@ -2651,6 +2711,7 @@ void Mapper::Initialize(kt_double rangeThreshold)
     m_pCorrelationSearchSpaceDimension->GetValue(),
     m_pCorrelationSearchSpaceResolution->GetValue(),
     m_pCorrelationSearchSpaceSmearDeviation->GetValue(),
+    m_pCorrelationSearchSpaceCoarseResolutionMultiplier->GetValue(),
     rangeThreshold);
   assert(m_pSequentialScanMatcher);
 

--- a/src/slam_mapper.cpp
+++ b/src/slam_mapper.cpp
@@ -259,6 +259,19 @@ void SMapper::configure(const NodeT & node)
   }
   mapper_->setParamCorrelationSearchSpaceSmearDeviation(correlation_search_space_smear_deviation);
 
+  int correlation_search_space_coarse_resolution_multiplier = 10;
+  if (!node->has_parameter("correlation_search_space_coarse_resolution_multiplier")) {
+    node->declare_parameter("correlation_search_space_coarse_resolution_multiplier", correlation_search_space_coarse_resolution_multiplier);
+  }
+  node->get_parameter("correlation_search_space_coarse_resolution_multiplier", correlation_search_space_coarse_resolution_multiplier);
+  if (correlation_search_space_coarse_resolution_multiplier <= 0) {
+    RCLCPP_WARN(node->get_logger(),
+      "You've set correlation_search_space_coarse_resolution_multiplier to be negative,"
+      "this isn't allowed so it will be set to default value 10.");
+    correlation_search_space_coarse_resolution_multiplier = 10;
+  }
+  mapper_->setParamCorrelationSearchSpaceCoarseResolutionMultiplier(correlation_search_space_coarse_resolution_multiplier);
+
   // Setting Correlation Parameters, Loop Closure Parameters
   double loop_search_space_dimension = 8.0;
   if (!node->has_parameter("loop_search_space_dimension")) {
@@ -298,6 +311,19 @@ void SMapper::configure(const NodeT & node)
     loop_search_space_smear_deviation = 0.03;
   }
   mapper_->setParamLoopSearchSpaceSmearDeviation(loop_search_space_smear_deviation);
+
+  int loop_search_space_coarse_resolution_multiplier = 10;
+  if (!node->has_parameter("loop_search_space_coarse_resolution_multiplier")) {
+    node->declare_parameter("loop_search_space_coarse_resolution_multiplier", loop_search_space_coarse_resolution_multiplier);
+  }
+  node->get_parameter("loop_search_space_coarse_resolution_multiplier", loop_search_space_coarse_resolution_multiplier);
+  if (loop_search_space_coarse_resolution_multiplier <= 0) {
+    RCLCPP_WARN(node->get_logger(),
+      "You've set loop_search_space_coarse_resolution_multiplier to be negative,"
+      "this isn't allowed so it will be set to default value 10.");
+    loop_search_space_coarse_resolution_multiplier = 10;
+  }
+  mapper_->setParamLoopSearchSpaceCoarseResolutionMultiplier(loop_search_space_coarse_resolution_multiplier);
 
   // Setting Scan Matcher Parameters
   double distance_variance_penalty = 0.5;

--- a/src/slam_mapper.cpp
+++ b/src/slam_mapper.cpp
@@ -259,7 +259,7 @@ void SMapper::configure(const NodeT & node)
   }
   mapper_->setParamCorrelationSearchSpaceSmearDeviation(correlation_search_space_smear_deviation);
 
-  int correlation_search_space_coarse_resolution_multiplier = 10;
+  int correlation_search_space_coarse_resolution_multiplier = 2;
   if (!node->has_parameter("correlation_search_space_coarse_resolution_multiplier")) {
     node->declare_parameter("correlation_search_space_coarse_resolution_multiplier", correlation_search_space_coarse_resolution_multiplier);
   }
@@ -267,8 +267,8 @@ void SMapper::configure(const NodeT & node)
   if (correlation_search_space_coarse_resolution_multiplier <= 0) {
     RCLCPP_WARN(node->get_logger(),
       "You've set correlation_search_space_coarse_resolution_multiplier to be negative,"
-      "this isn't allowed so it will be set to default value 10.");
-    correlation_search_space_coarse_resolution_multiplier = 10;
+      "this isn't allowed so it will be set to default value 2.");
+    correlation_search_space_coarse_resolution_multiplier = 2;
   }
   mapper_->setParamCorrelationSearchSpaceCoarseResolutionMultiplier(correlation_search_space_coarse_resolution_multiplier);
 
@@ -312,7 +312,7 @@ void SMapper::configure(const NodeT & node)
   }
   mapper_->setParamLoopSearchSpaceSmearDeviation(loop_search_space_smear_deviation);
 
-  int loop_search_space_coarse_resolution_multiplier = 10;
+  int loop_search_space_coarse_resolution_multiplier = 2;
   if (!node->has_parameter("loop_search_space_coarse_resolution_multiplier")) {
     node->declare_parameter("loop_search_space_coarse_resolution_multiplier", loop_search_space_coarse_resolution_multiplier);
   }
@@ -320,8 +320,8 @@ void SMapper::configure(const NodeT & node)
   if (loop_search_space_coarse_resolution_multiplier <= 0) {
     RCLCPP_WARN(node->get_logger(),
       "You've set loop_search_space_coarse_resolution_multiplier to be negative,"
-      "this isn't allowed so it will be set to default value 10.");
-    loop_search_space_coarse_resolution_multiplier = 10;
+      "this isn't allowed so it will be set to default value 2.");
+    loop_search_space_coarse_resolution_multiplier = 2;
   }
   mapper_->setParamLoopSearchSpaceCoarseResolutionMultiplier(loop_search_space_coarse_resolution_multiplier);
 


### PR DESCRIPTION
## Basic Info
This PR has no corresponding tickets
Tested _only_ on Jazzy, Ubuntu 24.04, small Gazebo simulations

## Summary

This exposes the multiplier between the fine search and coarse search for the Multi-resolution Correlative Scan Matcher. This multiplier is only for the translational search (x and y), not the angle. So it scales up the fine resolutions `loop_search_space_resolution` and `correlation_search_space_resolution` with the new parameters `loop_search_space_coarse_resolution_multiplier` and `correlation_search_space_coarse_resolution_multiplier`. It keeps the default scale at 2.

## Documentation updates

I updated the `README.md` file. I commented out new BOOST_SERIALIZATION_NVP parameters, as I noticed the PR for `m_pMinPassThrough` did.

## Future work

- It needs more rigorous testing
- I think there is a decent amount of repeat code (see calculations of `m_xPoses` and `xPoses`) that could be consolidated
- `fine_search_angle_offset` should be renamed `fine_search_angle_resolution`
- in this [paper](https://april.eecs.umich.edu/pdfs/olson2009icra.pdf), the process described in section D3 searches over multiple of the coarse steps (until no coarse score is larger than some calculated fine score). I think this would guarantee that the best fine resolution would be found, so large multipliers like 10 would have no reduction in scan matching quality and still increase performance.
