### PR TITLE
Adding restamping of TF from scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,8 @@ The following settings and options are exposed to you. My default configuration 
 
 `scan_topic` - scan topic, *absolute* path, i.e. `/scan` not `scan`
 
+`restamp_tf` - Whether to restamp the TF messages with the current time or use the scan's message. Default False.
+
 `scan_queue_size` - The number of scan messages to queue up before throwing away old ones. Should always be set to 1 in async mode
 
 `use_map_saver` - Instantiate the map saver service and self-subscribe to the map topic

--- a/config/mapper_params_lifelong.yaml
+++ b/config/mapper_params_lifelong.yaml
@@ -40,6 +40,7 @@ slam_toolbox:
     transform_publish_period: 0.02 #if 0 never publishes odometry
     map_update_interval: 5.0
     resolution: 0.05
+    restamp_tf: false
     min_laser_range: 0.0 #for rastering images
     max_laser_range: 20.0 #for rastering images
     minimum_time_interval: 0.5

--- a/config/mapper_params_localization.yaml
+++ b/config/mapper_params_localization.yaml
@@ -23,6 +23,7 @@ slam_toolbox:
     transform_publish_period: 0.02 #if 0 never publishes odometry
     map_update_interval: 5.0
     resolution: 0.05
+    restamp_tf: false
     min_laser_range: 0.0 #for rastering images
     max_laser_range: 20.0 #for rastering images
     minimum_time_interval: 0.5

--- a/config/mapper_params_offline.yaml
+++ b/config/mapper_params_offline.yaml
@@ -21,6 +21,7 @@ slam_toolbox:
     transform_publish_period: 0.02 #if 0 never publishes odometry
     map_update_interval: 10.0
     resolution: 0.05
+    restamp_tf: false
     min_laser_range: 0.0 #for rastering images
     max_laser_range: 20.0 #for rastering images
     minimum_time_interval: 0.5

--- a/config/mapper_params_online_async.yaml
+++ b/config/mapper_params_online_async.yaml
@@ -29,6 +29,7 @@ slam_toolbox:
     transform_publish_period: 0.02 #if 0 never publishes odometry
     map_update_interval: 5.0
     resolution: 0.05
+    restamp_tf: false
     min_laser_range: 0.0 #for rastering images
     max_laser_range: 20.0 #for rastering images
     minimum_time_interval: 0.5

--- a/config/mapper_params_online_sync.yaml
+++ b/config/mapper_params_online_sync.yaml
@@ -29,6 +29,7 @@ slam_toolbox:
     transform_publish_period: 0.02 #if 0 never publishes odometry
     map_update_interval: 5.0
     resolution: 0.05
+    restamp_tf: false
     min_laser_range: 0.0 #for rastering images
     max_laser_range: 20.0 #for rastering images
     minimum_time_interval: 0.5

--- a/include/slam_toolbox/slam_toolbox_common.hpp
+++ b/include/slam_toolbox/slam_toolbox_common.hpp
@@ -173,6 +173,7 @@ protected:
   double position_covariance_scale_;
   double yaw_covariance_scale_;
   bool first_measurement_, enable_interactive_mode_;
+  bool restamp_tf_;
 
   // Book keeping
   std::unique_ptr<mapper_utils::SMapper> smapper_;

--- a/src/slam_toolbox_common.cpp
+++ b/src/slam_toolbox_common.cpp
@@ -393,6 +393,12 @@ void SlamToolbox::setParams()
   }
   enable_interactive_mode_ = this->get_parameter("enable_interactive_mode").as_bool();
 
+  restamp_tf_ = false;
+  if (!this->has_parameter("restamp_tf")) {
+    this->declare_parameter("restamp_tf", restamp_tf_);
+  }
+  restamp_tf_ = this->get_parameter("restamp_tf").as_bool();
+
   double tmp_val = 0.5;
   if (!this->has_parameter("transform_timeout")) {
     this->declare_parameter("transform_timeout", tmp_val);
@@ -488,7 +494,11 @@ void SlamToolbox::publishTransformLoop(
         msg.transform = tf2::toMsg(map_to_odom_);
         msg.child_frame_id = odom_frame_;
         msg.header.frame_id = map_frame_;
-        msg.header.stamp = scan_timestamp + transform_timeout_;
+        if (restamp_tf_) {
+          msg.header.stamp = now() + transform_timeout_;
+        } else {
+          msg.header.stamp = scan_timestamp + transform_timeout_;
+        }
         tfB_->sendTransform(msg);
       }
     }


### PR DESCRIPTION
Solves https://github.com/SteveMacenski/slam_toolbox/issues/717 and provides an option to restamp TF based on the current clock time instead of the time of the last processed scan, which may be necessary due to poor time synchronization between sensors. Something like PTP should be used in all cases where possible, but sometimes this can be helpful for R&D, hobbyists that don't need high accuracy of time synchronization, or sensors that don't support time synchronization (which ... probably doesn't exist, but may)