### PR TITLE
Fix: Add explicit OpenMP linkage to ceres_solver_plugin target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,6 @@ find_package(rviz_rendering REQUIRED)
 find_package(interactive_markers REQUIRED)
 find_package(Qt5 REQUIRED COMPONENTS Core Gui Widgets Test Concurrent)
 find_package(rclcpp_components REQUIRED)
-find_package(OpenMP REQUIRED)
 
 #karto_sdk lib
 set(BUILD_SHARED_LIBS ON)
@@ -88,6 +87,7 @@ find_package(CHOLMOD REQUIRED)
 find_package(CSparse REQUIRED)
 find_package(G2O REQUIRED)
 find_package(LAPACK REQUIRED)
+find_package(OpenMP REQUIRED)
 find_package(Ceres REQUIRED COMPONENTS SuiteSparse)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
@@ -193,7 +193,6 @@ target_link_libraries(ceres_solver_plugin PUBLIC
 target_link_libraries(ceres_solver_plugin PUBLIC ${CERES_LIBRARIES}
                                           ${Boost_LIBRARIES}
                                           kartoSlamToolbox
-                                          OpenMP::OpenMP_CXX
 )
 rosidl_get_typesupport_target(cpp_typesupport_target ${PROJECT_NAME} "rosidl_typesupport_cpp")
 target_link_libraries(ceres_solver_plugin PUBLIC "${cpp_typesupport_target}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ find_package(rviz_rendering REQUIRED)
 find_package(interactive_markers REQUIRED)
 find_package(Qt5 REQUIRED COMPONENTS Core Gui Widgets Test Concurrent)
 find_package(rclcpp_components REQUIRED)
+find_package(OpenMP REQUIRED)
 
 #karto_sdk lib
 set(BUILD_SHARED_LIBS ON)
@@ -192,6 +193,7 @@ target_link_libraries(ceres_solver_plugin PUBLIC
 target_link_libraries(ceres_solver_plugin PUBLIC ${CERES_LIBRARIES}
                                           ${Boost_LIBRARIES}
                                           kartoSlamToolbox
+                                          OpenMP::OpenMP_CXX
 )
 rosidl_get_typesupport_target(cpp_typesupport_target ${PROJECT_NAME} "rosidl_typesupport_cpp")
 target_link_libraries(ceres_solver_plugin PUBLIC "${cpp_typesupport_target}")

--- a/package.xml
+++ b/package.xml
@@ -29,6 +29,7 @@
   <build_depend>std_msgs</build_depend>
   <build_depend>suitesparse</build_depend>
   <build_depend>liblapack-dev</build_depend>
+  <build_depend>libomp-dev</build_depend>
   <build_depend>libceres-dev</build_depend>
   <build_depend>tf2_geometry_msgs</build_depend>
   <build_depend>tbb</build_depend>
@@ -61,6 +62,7 @@
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>suitesparse</exec_depend>
   <exec_depend>liblapack-dev</exec_depend>
+  <exec_depend>libomp-dev</exec_depend>
   <exec_depend>libceres-dev</exec_depend>
   <exec_depend>tf2_geometry_msgs</exec_depend>
   <exec_depend>tbb</exec_depend>

--- a/package.xml
+++ b/package.xml
@@ -30,7 +30,6 @@
   <build_depend>suitesparse</build_depend>
   <build_depend>liblapack-dev</build_depend>
   <build_depend>libceres-dev</build_depend>
-  <build_depend>ceres-solver</build_depend>
   <build_depend>tf2_geometry_msgs</build_depend>
   <build_depend>tbb</build_depend>
   <build_depend>libqt5-core</build_depend>

--- a/package.xml
+++ b/package.xml
@@ -30,6 +30,7 @@
   <build_depend>suitesparse</build_depend>
   <build_depend>liblapack-dev</build_depend>
   <build_depend>libceres-dev</build_depend>
+  <build_depend>ceres-solver</build_depend>
   <build_depend>tf2_geometry_msgs</build_depend>
   <build_depend>tbb</build_depend>
   <build_depend>libqt5-core</build_depend>


### PR DESCRIPTION
This PR fixes a linker issue on macOS (ARM64) caused by missing OpenMP symbols during the build of `ceres_solver_plugin`.

-  Added `find_package(OpenMP REQUIRED)` to ensure OpenMP is properly detected.
- Linked `OpenMP::OpenMP_CXX` explicitly to the `ceres_solver_plugin` target alongside other dependencies (CERES_LIBRARIES, Boost_LIBRARIES, TBB_LIBRARIES, kartoSlamToolbox).
- This resolves unresolved symbol errors related to OpenMP runtime during linking on Apple Clang and ensures consistent build behavior across platforms.
- Add `<build_depend>ceres-solver</build_depend>` to package.xml to ensure colcon builds ceres-solver first on macOS
