### PR TITLE
Add pose graph & node event publisher

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,6 +114,11 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   srv/AddSubmap.srv
   srv/DeserializePoseGraph.srv
   srv/SerializePoseGraph.srv
+  msg/NewNodeEvent.msg
+  msg/LoopClosureEvent.msg
+  msg/GraphNode.msg
+  msg/GraphEdge.msg
+  msg/PoseGraph.msg
   DEPENDENCIES builtin_interfaces geometry_msgs std_msgs nav_msgs visualization_msgs
 )
 
@@ -149,7 +154,7 @@ target_link_libraries(ceres_solver_plugin "${cpp_typesupport_target}")
 pluginlib_export_plugin_description_file(slam_toolbox solver_plugins.xml)
 
 #### Tool lib for mapping
-add_library(toolbox_common src/slam_toolbox_common.cpp src/map_saver.cpp src/loop_closure_assistant.cpp src/laser_utils.cpp src/slam_mapper.cpp)
+add_library(toolbox_common src/slam_toolbox_common.cpp src/map_saver.cpp src/loop_closure_assistant.cpp src/loop_closure_listener.cpp src/laser_utils.cpp src/slam_mapper.cpp)
 ament_target_dependencies(toolbox_common
   ${dependencies}
 )
@@ -244,6 +249,7 @@ install(FILES solver_plugins.xml rviz_plugins.xml
 
 ament_export_include_directories(include)
 ament_export_libraries(${libraries} kartoSlamToolbox)
+ament_export_dependencies(${dependencies} rosidl_default_runtime)
 ament_export_dependencies(${dependencies})
 ament_export_targets(SlamToolboxPlugin HAS_LIBRARY_TARGET)
 ament_package()

--- a/README.md
+++ b/README.md
@@ -178,6 +178,9 @@ The following are the services/topics that are exposed for use. See the rviz plu
 |-----|----|----|
 | map  | `nav_msgs/OccupancyGrid` | occupancy grid representation of the pose-graph at `map_update_interval` frequency | 
 | pose | `geometry_msgs/PoseWithCovarianceStamped` | pose of the base_frame in the configured map_frame along with the covariance calculated from the scan match |
+| /slam_toolbox/new_node_event | `slam_toolbox/msg/NewNodeEvent` | event message triggered on new pose graph node |
+| /slam_toolbox/loop_closure_event | `slam_toolbox/msg/LoopClosureEvent` | event message triggered on loop closure |
+| /slam_toolbox/pose_graph | `slam_toolbox/msg/PoseGraph` | minimal pose graph message: nodes, edges, poses only. No sensor data. Published on new node / loop closure event. |
 
 ## Exposed Services
 

--- a/include/slam_toolbox/loop_closure_listener.hpp
+++ b/include/slam_toolbox/loop_closure_listener.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <memory>
+#include <functional>
+#include <string>
+
+#include <rclcpp/rclcpp.hpp>
+#include <rclcpp_lifecycle/lifecycle_publisher.hpp>
+
+#include "slam_toolbox/msg/loop_closure_event.hpp"
+
+#include "karto_sdk/Mapper.h"
+
+namespace slam_toolbox {
+
+
+class LoopClosureListener final : public karto::MapperLoopClosureListener {
+public:
+  LoopClosureListener(
+      std::weak_ptr<rclcpp_lifecycle::LifecyclePublisher<slam_toolbox::msg::LoopClosureEvent>> loop_closure_event_pub,
+      std::weak_ptr<rclcpp::Clock> clock,
+      std::function<void()> loop_closure_callback);
+
+  void EndLoopClosure(const std::string & rInfo) override;
+
+private:
+  std::weak_ptr<rclcpp_lifecycle::LifecyclePublisher<slam_toolbox::msg::LoopClosureEvent>> loop_closure_event_pub_;
+  std::weak_ptr<rclcpp::Clock> clock_;
+  std::function<void()> loop_closure_callback_;
+};
+
+} // namespace slam_toolbox

--- a/include/slam_toolbox/slam_toolbox_common.hpp
+++ b/include/slam_toolbox/slam_toolbox_common.hpp
@@ -28,6 +28,7 @@
 #include <cstdlib>
 #include <memory>
 #include <fstream>
+#include <atomic>
 
 #include "lifecycle_msgs/msg/state.hpp"
 #include "rclcpp/rclcpp.hpp"
@@ -53,6 +54,7 @@
 #include "slam_toolbox/get_pose_helper.hpp"
 #include "slam_toolbox/map_saver.hpp"
 #include "slam_toolbox/loop_closure_assistant.hpp"
+#include "slam_toolbox/loop_closure_listener.hpp"
 
 namespace slam_toolbox
 {
@@ -104,6 +106,7 @@ protected:
     const std::shared_ptr<rmw_request_id_t> request_header,
     const std::shared_ptr<slam_toolbox::srv::DeserializePoseGraph::Request> req,
     std::shared_ptr<slam_toolbox::srv::DeserializePoseGraph::Response> resp);
+  void loopClosureCallback();
 
   // Loaders
   void loadSerializedPoseGraph(std::unique_ptr<karto::Mapper> &, std::unique_ptr<karto::Dataset> &);
@@ -133,6 +136,10 @@ protected:
     const Pose2 & pose,
     const Matrix3 & cov,
     const rclcpp::Time & t);
+  void requestPoseGraphPublish();
+  void publishPoseGraph();
+  void poseGraphPublishTimerCallback();
+  void publishNewNodeEvent(const karto::LocalizedRangeScan* lrs);
 
   // pausing bits
   bool isPaused(const PausedApplication & app);
@@ -152,6 +159,12 @@ protected:
   std::shared_ptr<rclcpp_lifecycle::LifecyclePublisher<nav_msgs::msg::MapMetaData>> sstm_;
   std::shared_ptr<rclcpp_lifecycle::LifecyclePublisher<
       geometry_msgs::msg::PoseWithCovarianceStamped>> pose_pub_;
+  std::shared_ptr<rclcpp_lifecycle::LifecyclePublisher<
+      slam_toolbox::msg::PoseGraph>> pose_graph_pub_;
+  std::shared_ptr<rclcpp_lifecycle::LifecyclePublisher<
+      slam_toolbox::msg::NewNodeEvent>> new_node_event_pub_;
+  std::shared_ptr<rclcpp_lifecycle::LifecyclePublisher<
+      slam_toolbox::msg::LoopClosureEvent>> loop_closure_event_pub_;
   std::shared_ptr<rclcpp::Service<nav_msgs::srv::GetMap>> ssMap_;
   std::shared_ptr<rclcpp::Service<slam_toolbox::srv::Pause>> ssPauseMeasurements_;
   std::shared_ptr<rclcpp::Service<slam_toolbox::srv::SerializePoseGraph>> ssSerialize_;
@@ -181,6 +194,7 @@ protected:
   std::unique_ptr<map_saver::MapSaver> map_saver_;
   std::unique_ptr<loop_closure_assistant::LoopClosureAssistant> closure_assistant_;
   std::unique_ptr<laser_utils::ScanHolder> scan_holder_;
+  std::unique_ptr<slam_toolbox::LoopClosureListener> loop_closure_listener_;
 
   // Internal state
   std::vector<std::unique_ptr<boost::thread>> threads_;
@@ -191,6 +205,10 @@ protected:
   ProcessType processor_type_;
   std::unique_ptr<karto::Pose2> process_near_pose_;
   tf2::Transform reprocessing_transform_;
+
+  // Pose graph publishing control
+  std::atomic<bool> publish_pose_graph_requested_{false};
+  rclcpp::TimerBase::SharedPtr pose_graph_timer_;
 
   // pluginlib
   pluginlib::ClassLoader<karto::ScanSolver> solver_loader_;

--- a/include/slam_toolbox/toolbox_msgs.hpp
+++ b/include/slam_toolbox/toolbox_msgs.hpp
@@ -39,5 +39,10 @@
 #include "slam_toolbox/srv/deserialize_pose_graph.hpp"
 #include "slam_toolbox/srv/merge_maps.hpp"
 #include "slam_toolbox/srv/add_submap.hpp"
+#include "slam_toolbox/msg/pose_graph.hpp"
+#include "slam_toolbox/msg/graph_node.hpp"
+#include "slam_toolbox/msg/graph_edge.hpp"
+#include "slam_toolbox/msg/new_node_event.hpp"
+#include "slam_toolbox/msg/loop_closure_event.hpp"
 
 #endif  // SLAM_TOOLBOX__TOOLBOX_MSGS_HPP_

--- a/msg/GraphEdge.msg
+++ b/msg/GraphEdge.msg
@@ -1,0 +1,4 @@
+int32 source_id
+int32 target_id
+geometry_msgs/Pose2D relative_pose
+float64[9] covariance

--- a/msg/GraphNode.msg
+++ b/msg/GraphNode.msg
@@ -1,0 +1,2 @@
+int32 node_id
+geometry_msgs/Pose2D pose

--- a/msg/LoopClosureEvent.msg
+++ b/msg/LoopClosureEvent.msg
@@ -1,0 +1,1 @@
+builtin_interfaces/Time stamp

--- a/msg/NewNodeEvent.msg
+++ b/msg/NewNodeEvent.msg
@@ -1,0 +1,3 @@
+int32 new_node_id
+builtin_interfaces/Time stamp
+geometry_msgs/Pose2D pose

--- a/msg/PoseGraph.msg
+++ b/msg/PoseGraph.msg
@@ -1,0 +1,3 @@
+std_msgs/Header header
+GraphNode[] nodes
+GraphEdge[] edges

--- a/package.xml
+++ b/package.xml
@@ -41,6 +41,7 @@
   <build_depend>bondcpp</build_depend>
   <build_depend>bond</build_depend>
   <build_depend>rclcpp_lifecycle</build_depend>
+  <build_depend>geometry_msgs</build_depend>
   <depend>rviz_common</depend>
   <depend>rviz_default_plugins</depend>
   <depend>rviz_ogre_vendor</depend>
@@ -73,6 +74,8 @@
   <exec_depend>bondcpp</exec_depend>
   <exec_depend>bond</exec_depend>
   <exec_depend>rclcpp_lifecycle</exec_depend>
+  <exec_depend>rosidl_default_runtime</exec_depend>
+  <exec_depend>geometry_msgs</exec_depend>
 
   <exec_depend>libqt5-core</exec_depend>
   <exec_depend>libqt5-gui</exec_depend>

--- a/src/loop_closure_listener.cpp
+++ b/src/loop_closure_listener.cpp
@@ -1,0 +1,29 @@
+#include "slam_toolbox/loop_closure_listener.hpp"
+
+namespace slam_toolbox {
+
+LoopClosureListener::LoopClosureListener(
+    std::weak_ptr<rclcpp_lifecycle::LifecyclePublisher<slam_toolbox::msg::LoopClosureEvent>> loop_closure_event_pub,
+    std::weak_ptr<rclcpp::Clock> clock,
+    std::function<void()> loop_closure_callback)
+: loop_closure_event_pub_(std::move(loop_closure_event_pub)),
+  clock_(std::move(clock)),
+  loop_closure_callback_(std::move(loop_closure_callback)) {}
+
+void LoopClosureListener::EndLoopClosure(const std::string & /*rInfo*/) {
+  auto spub = loop_closure_event_pub_.lock();
+  auto sclk = clock_.lock();
+  if (!spub || !sclk) {
+    return;
+  }
+
+  slam_toolbox::msg::LoopClosureEvent event;
+  event.stamp = sclk->now();
+  spub->publish(event);
+
+  if (loop_closure_callback_) {
+    loop_closure_callback_();
+  }
+}
+
+} // namespace slam_toolbox

--- a/src/slam_toolbox_common.cpp
+++ b/src/slam_toolbox_common.cpp
@@ -22,6 +22,7 @@
 #include <chrono>
 #include "slam_toolbox/slam_toolbox_common.hpp"
 #include "slam_toolbox/serialization.hpp"
+#include "slam_toolbox/loop_closure_listener.hpp"
 
 namespace slam_toolbox
 {
@@ -145,10 +146,23 @@ CallbackReturn SlamToolbox::on_activate(const rclcpp_lifecycle::State &)
   sst_->on_activate();
   sstm_->on_activate();
   pose_pub_->on_activate();
+  pose_graph_pub_->on_activate();
+  new_node_event_pub_->on_activate();
+  loop_closure_event_pub_->on_activate();
+
   closure_assistant_ =
     std::make_unique<loop_closure_assistant::LoopClosureAssistant>(
     shared_from_this(), smapper_->getMapper(), scan_holder_.get(),
     state_, processor_type_);
+
+  loop_closure_listener_ =
+    std::make_unique<slam_toolbox::LoopClosureListener>(
+      loop_closure_event_pub_,
+      this->get_clock(),
+      std::bind(&SlamToolbox::loopClosureCallback, this)
+    );
+  smapper_->getMapper()->AddListener(loop_closure_listener_.get());
+
   reprocessing_transform_.setIdentity();
 
   double transform_publish_period = 0.05;
@@ -161,6 +175,12 @@ CallbackReturn SlamToolbox::on_activate(const rclcpp_lifecycle::State &)
       this, transform_publish_period)));
   threads_.push_back(std::make_unique<boost::thread>(
       boost::bind(&SlamToolbox::publishVisualizations, this)));
+
+  // Create pose graph publish timer (10Hz)
+  pose_graph_timer_ = this->create_wall_timer(
+    std::chrono::milliseconds(100),
+    std::bind(&SlamToolbox::poseGraphPublishTimerCallback, this)
+  );
 
   if (use_lifecycle_manager_) {
     // create bond connection
@@ -182,9 +202,23 @@ CallbackReturn SlamToolbox::on_deactivate(const rclcpp_lifecycle::State &)
   }
   threads_.clear();
   closure_assistant_.reset();
+  if (smapper_ && smapper_->getMapper() && loop_closure_listener_) {
+    smapper_->getMapper()->RemoveListener(loop_closure_listener_.get());
+  }
+  loop_closure_listener_.reset();
+
+  // Cancel and reset pose graph timer
+  if (pose_graph_timer_) {
+    pose_graph_timer_->cancel();
+    pose_graph_timer_.reset();
+  }
+
   sst_->on_deactivate();
   sstm_->on_deactivate();
   pose_pub_->on_deactivate();
+  pose_graph_pub_->on_deactivate();
+  new_node_event_pub_->on_deactivate();
+  loop_closure_event_pub_->on_deactivate();
 
   // reset interfaces
   scan_filter_.reset();
@@ -196,6 +230,7 @@ CallbackReturn SlamToolbox::on_deactivate(const rclcpp_lifecycle::State &)
   sstm_.reset();
   sst_.reset();
   pose_pub_.reset();
+  pose_graph_pub_.reset();
 
   if (use_lifecycle_manager_) {
     // destroy bond connection
@@ -446,6 +481,13 @@ void SlamToolbox::setROSInterfaces()
     "slam_toolbox/deserialize_map",
     std::bind(&SlamToolbox::deserializePoseGraphCallback, this,
     std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
+  pose_graph_pub_ = this->create_publisher<slam_toolbox::msg::PoseGraph>(
+    "slam_toolbox/pose_graph",
+    rclcpp::QoS(rclcpp::KeepLast(1)).transient_local().reliable());
+  new_node_event_pub_ = this->create_publisher<slam_toolbox::msg::NewNodeEvent>(
+    "slam_toolbox/new_node_event", 10);
+  loop_closure_event_pub_ = this->create_publisher<slam_toolbox::msg::LoopClosureEvent>(
+    "slam_toolbox/loop_closure_event", 10);
 
   scan_filter_sub_ =
     std::make_unique<message_filters::Subscriber<sensor_msgs::msg::LaserScan,
@@ -844,6 +886,8 @@ LocalizedRangeScan * SlamToolbox::addScan(
     dataset_->Add(range_scan);
 
     publishPose(range_scan->GetCorrectedPose(), covariance, scan->header.stamp);
+    publishNewNodeEvent(range_scan);
+    requestPoseGraphPublish();
   } else {
     delete range_scan;
     range_scan = nullptr;
@@ -875,6 +919,126 @@ void SlamToolbox::publishPose(
   pose_msg.pose.covariance[35] = cov(2, 2) * yaw_covariance_scale_;      // yaw
 
   pose_pub_->publish(pose_msg);
+}
+
+/*****************************************************************************/
+void SlamToolbox::requestPoseGraphPublish()
+/*****************************************************************************/
+{
+  // Set the flag to request pose graph publishing via timer
+  publish_pose_graph_requested_.store(true);
+}
+
+/*****************************************************************************/
+void SlamToolbox::poseGraphPublishTimerCallback()
+/*****************************************************************************/
+{
+  // Check if pose graph publishing was requested
+  bool was_requested = publish_pose_graph_requested_.exchange(false);
+  
+  if (was_requested) {
+    // Try to acquire mutex with try_lock
+    boost::unique_lock<boost::mutex> lock(smapper_mutex_, boost::defer_lock);
+    if (lock.try_lock()) {
+      // Successfully acquired mutex, publish pose graph
+      publishPoseGraph();
+    } else {
+      // Failed to acquire mutex, set the flag again to retry later
+      publish_pose_graph_requested_.store(true);
+    }
+  }
+}
+
+/*****************************************************************************/
+void SlamToolbox::publishPoseGraph()
+/*****************************************************************************/
+{
+  if (pose_graph_pub_->get_subscription_count() == 0) {
+    return;
+  }
+
+  slam_toolbox::msg::PoseGraph msg;
+
+  auto * graph = smapper_->getMapper()->GetGraph();
+  if (!graph) return;
+
+  msg.header.stamp = this->get_clock()->now();
+  msg.header.frame_id = map_frame_;
+
+  VerticeMap mapper_vertices = graph->GetVertices();
+  for (auto vertex_map_it = mapper_vertices.begin();
+       vertex_map_it != mapper_vertices.end(); ++vertex_map_it)
+  {
+    for (auto vertex_it = vertex_map_it->second.begin();
+         vertex_it != vertex_map_it->second.end(); ++vertex_it)
+    {
+      if (!vertex_it->second) { continue; }
+      auto * lrs = vertex_it->second->GetObject();
+      if (!lrs) { continue; }
+
+      slam_toolbox::msg::GraphNode node_msg;
+      node_msg.node_id = lrs->GetUniqueId();
+      node_msg.pose.x = lrs->GetCorrectedPose().GetX();
+      node_msg.pose.y = lrs->GetCorrectedPose().GetY();
+      node_msg.pose.theta = lrs->GetCorrectedPose().GetHeading();
+      msg.nodes.push_back(node_msg);
+    }
+  }
+
+  EdgeVector mapper_edges = graph->GetEdges();
+  for (auto edges_it = mapper_edges.begin();
+       edges_it != mapper_edges.end(); ++edges_it)
+  {
+    if (!(*edges_it)) { continue; }
+
+    slam_toolbox::msg::GraphEdge edge_msg;
+    auto * src = (*edges_it)->GetSource();
+    auto * dst = (*edges_it)->GetTarget();
+    if (!src || !dst || !src->GetObject() || !dst->GetObject()) {
+      continue;
+    }
+    edge_msg.source_id = src->GetObject()->GetUniqueId();
+    edge_msg.target_id = dst->GetObject()->GetUniqueId();
+
+    karto::EdgeLabel * base_label = (*edges_it)->GetLabel();
+    if (!base_label) { continue; }
+    auto * link_info = dynamic_cast<karto::LinkInfo *>(base_label);
+    if (!link_info) { continue; }
+
+    karto::Pose2 rel_pose = link_info->GetPoseDifference();
+    edge_msg.relative_pose.x = rel_pose.GetX();
+    edge_msg.relative_pose.y = rel_pose.GetY();
+    edge_msg.relative_pose.theta = rel_pose.GetHeading();
+
+    karto::Matrix3 cov = link_info->GetCovariance();
+    for (int r = 0; r < 3; ++r) {
+      for (int c = 0; c < 3; ++c) {
+        edge_msg.covariance[r * 3 + c] = cov(r, c);
+      }
+    }
+
+    msg.edges.push_back(edge_msg);
+  }
+
+  pose_graph_pub_->publish(msg);
+}
+
+/*****************************************************************************/
+void SlamToolbox::publishNewNodeEvent(const karto::LocalizedRangeScan* lrs)
+/*****************************************************************************/
+{
+  if (!new_node_event_pub_ || lrs == nullptr) {
+    return;
+  }
+
+  slam_toolbox::msg::NewNodeEvent ev;
+  ev.stamp = scan_header.stamp;
+  ev.new_node_id = lrs->GetUniqueId();
+  ev.pose.x = lrs->GetCorrectedPose().GetX();
+  ev.pose.y = lrs->GetCorrectedPose().GetY();
+  ev.pose.theta = lrs->GetCorrectedPose().GetHeading();
+
+  new_node_event_pub_->publish(ev);
 }
 
 /*****************************************************************************/
@@ -1070,6 +1234,13 @@ bool SlamToolbox::deserializePoseGraphCallback(
   }
 
   return true;
+}
+
+/*****************************************************************************/
+void SlamToolbox::loopClosureCallback()
+/*****************************************************************************/
+{
+  requestPoseGraphPublish();
 }
 
 }  // namespace slam_toolbox


### PR DESCRIPTION
<h2>Basic Info</h2>

| Info | Please fill out this column |
| --- | --- |
| Ticket(s) this addresses | https://github.com/SteveMacenski/slam_toolbox/issues/803 |
| Primary OS tested on | Ubuntu 22.04 |
| Robotic platform tested on | Turtlebot3 Burger (gazebo simulation) |

<hr>

<h2>Description of contribution in a few bullet points</h2>

<ul>
<li><strong>Loop-closure event publisher</strong>
  <ul>
    <li>Registers a <code>karto::MapperLoopClosureListener</code> and publishes <strong><code>/slam_toolbox/loop_closure_event</code></strong> when Karto signals <code>EndLoopClosure</code>.</li>
    <li>The message carries only a <strong>timestamp</strong>.</li>
  </ul>
</li>
<li><strong>New-node event publisher</strong>
  <ul>
    <li>Publishes <strong><code>/slam_toolbox/new_node_event</code></strong> when a new node is generated.</li>
  </ul>
</li>
<li><strong>Asynchronous pose-graph publish on loop closure and on new-node</strong>
  <ul>
    <li>After emitting the loop-closure event, <strong>asynchronously publishes</strong> <code>/slam_toolbox/pose_graph</code> once the internal mapping mutex becomes available, instead of invoking it directly inside the callback.</li>
    <li>This ensures non-blocking and thread-safe behavior while keeping the publication nearly real-time.</li>
    <li>Also performs the same asynchronous publish when a <strong>new node</strong> is added.</li>
  </ul>
</li>
</ul>

<h2>Description of documentation updates required from your changes</h2>
Documentation updated

<hr>

<h2>Future work that may be required in bullet points</h2>
N/A

<hr>

<h2>Performance Metrics</h2>

| Metric | Value / Observation |
| --- | --- |
| Pose-graph message size (50 nodes) | 8.10 KB |
| Pose-graph message size (100 nodes) | 15.88 KB |
| Pose-graph message size (150 nodes) | 23.96 KB |


https://github.com/user-attachments/assets/621636e0-2aad-4f53-aa29-fae2e0e5a4c7



<hr>

<h2>Question for the Maintainer</h2>

I noticed that all other ROS distro branches (e.g., Foxy, Galactic, Rolling) use the lifecycle version,  
so I made these changes on the **`humble_lifecycle`** branch for consistency.  
Is this the correct branch to work on?  

Also, could you please clarify why only the Humble version has **two separate branches**  
(`humble` and `humble_lifecycle`), while the others maintain just a single lifecycle version?
