### PR TITLE
Add substitutions to all launches

### DIFF
--- a/launch/lifelong_launch.py
+++ b/launch/lifelong_launch.py
@@ -18,6 +18,7 @@ def generate_launch_description():
     autostart = LaunchConfiguration('autostart')
     use_lifecycle_manager = LaunchConfiguration("use_lifecycle_manager")
     slam_params_file = LaunchConfiguration('slam_params_file')
+    use_sim_time = LaunchConfiguration('use_sim_time')
 
     declare_autostart_cmd = DeclareLaunchArgument(
         'autostart', default_value='true',
@@ -31,6 +32,10 @@ def generate_launch_description():
         default_value=os.path.join(get_package_share_directory("slam_toolbox"),
                                    'config', 'mapper_params_lifelong.yaml'),
         description='Full path to the ROS2 parameters file to use for the slam_toolbox node')
+    declare_use_sim_time_argument = DeclareLaunchArgument(
+        'use_sim_time',
+        default_value='true',
+        description='Use simulation/Gazebo clock')
 
     # Perform substitution `$find-pkg-share`
     slam_params_file_w_subst = ParameterFile(
@@ -41,7 +46,10 @@ def generate_launch_description():
     start_lifelong_slam_toolbox_node = LifecycleNode(
           parameters=[
             slam_params_file_w_subst,
-            {'use_lifecycle_manager': use_lifecycle_manager}
+            {
+              'use_lifecycle_manager': use_lifecycle_manager,
+              'use_sim_time': use_sim_time
+            }
           ],
           package='slam_toolbox',
           executable='lifelong_slam_toolbox_node',
@@ -79,6 +87,7 @@ def generate_launch_description():
     ld.add_action(declare_autostart_cmd)
     ld.add_action(declare_use_lifecycle_manager)
     ld.add_action(declare_slam_params_file_cmd)
+    ld.add_action(declare_use_sim_time_argument)
     ld.add_action(start_lifelong_slam_toolbox_node)
     ld.add_action(configure_event)
     ld.add_action(activate_event)

--- a/launch/lifelong_launch.py
+++ b/launch/lifelong_launch.py
@@ -1,3 +1,5 @@
+import os
+
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch.actions import (DeclareLaunchArgument, EmitEvent, LogInfo,
@@ -15,6 +17,7 @@ from lifecycle_msgs.msg import Transition
 def generate_launch_description():
     autostart = LaunchConfiguration('autostart')
     use_lifecycle_manager = LaunchConfiguration("use_lifecycle_manager")
+    slam_params_file = LaunchConfiguration('slam_params_file')
 
     declare_autostart_cmd = DeclareLaunchArgument(
         'autostart', default_value='true',
@@ -23,10 +26,21 @@ def generate_launch_description():
     declare_use_lifecycle_manager = DeclareLaunchArgument(
         'use_lifecycle_manager', default_value='false',
         description='Enable bond connection during node activation')
+    declare_slam_params_file_cmd = DeclareLaunchArgument(
+        'slam_params_file',
+        default_value=os.path.join(get_package_share_directory("slam_toolbox"),
+                                   'config', 'mapper_params_lifelong.yaml'),
+        description='Full path to the ROS2 parameters file to use for the slam_toolbox node')
 
+    # Perform substitution `$find-pkg-share`
+    slam_params_file_w_subst = ParameterFile(
+        slam_params_file,
+        allow_substs=True,
+    )
+    
     start_lifelong_slam_toolbox_node = LifecycleNode(
           parameters=[
-            get_package_share_directory("slam_toolbox") + '/config/mapper_params_lifelong.yaml',
+            slam_params_file_w_subst,
             {'use_lifecycle_manager': use_lifecycle_manager}
           ],
           package='slam_toolbox',
@@ -64,6 +78,7 @@ def generate_launch_description():
 
     ld.add_action(declare_autostart_cmd)
     ld.add_action(declare_use_lifecycle_manager)
+    ld.add_action(declare_slam_params_file_cmd)
     ld.add_action(start_lifelong_slam_toolbox_node)
     ld.add_action(configure_event)
     ld.add_action(activate_event)

--- a/launch/lifelong_launch.py
+++ b/launch/lifelong_launch.py
@@ -12,6 +12,7 @@ from launch_ros.actions import LifecycleNode
 from launch_ros.event_handlers import OnStateTransition
 from launch_ros.events.lifecycle import ChangeState
 from lifecycle_msgs.msg import Transition
+from launch_ros.descriptions import ParameterFile
 
 
 def generate_launch_description():

--- a/launch/localization_launch.py
+++ b/launch/localization_launch.py
@@ -38,9 +38,15 @@ def generate_launch_description():
         'use_lifecycle_manager', default_value='false',
         description='Enable bond connection during node activation')
 
+    # Perform substitution `$find-pkg-share`
+    slam_params_file_w_subst = ParameterFile(
+        slam_params_file,
+        allow_substs=True,
+    )
+    
     start_localization_slam_toolbox_node = LifecycleNode(
         parameters=[
-          slam_params_file,
+          slam_params_file_w_subst,
           {
             'use_lifecycle_manager': use_lifecycle_manager,
             'use_sim_time': use_sim_time

--- a/launch/localization_launch.py
+++ b/launch/localization_launch.py
@@ -13,6 +13,7 @@ from launch_ros.actions import LifecycleNode
 from launch_ros.event_handlers import OnStateTransition
 from launch_ros.events.lifecycle import ChangeState
 from lifecycle_msgs.msg import Transition
+from launch_ros.descriptions import ParameterFile
 
 
 def generate_launch_description():

--- a/launch/online_async_launch.py
+++ b/launch/online_async_launch.py
@@ -37,9 +37,15 @@ def generate_launch_description():
                                    'config', 'mapper_params_online_async.yaml'),
         description='Full path to the ROS2 parameters file to use for the slam_toolbox node')
 
+    # Perform substitution `$find-pkg-share`
+    slam_params_file_w_subst = ParameterFile(
+        slam_params_file,
+        allow_substs=True,
+    )
+    
     start_async_slam_toolbox_node = LifecycleNode(
         parameters=[
-          slam_params_file,
+          slam_params_file_w_subst,
           {
             'use_lifecycle_manager': use_lifecycle_manager,
             'use_sim_time': use_sim_time

--- a/launch/online_async_launch.py
+++ b/launch/online_async_launch.py
@@ -12,6 +12,7 @@ from launch_ros.actions import LifecycleNode
 from launch_ros.event_handlers import OnStateTransition
 from launch_ros.events.lifecycle import ChangeState
 from lifecycle_msgs.msg import Transition
+from launch_ros.descriptions import ParameterFile
 
 
 def generate_launch_description():

--- a/launch/online_sync_launch.py
+++ b/launch/online_sync_launch.py
@@ -37,9 +37,15 @@ def generate_launch_description():
                                    'config', 'mapper_params_online_sync.yaml'),
         description='Full path to the ROS2 parameters file to use for the slam_toolbox node')
 
+    # Perform substitution `$find-pkg-share`
+    slam_params_file_w_subst = ParameterFile(
+        slam_params_file,
+        allow_substs=True,
+    )
+    
     start_sync_slam_toolbox_node = LifecycleNode(
         parameters=[
-          slam_params_file,
+          slam_params_file_w_subst,
           {
             'use_lifecycle_manager': use_lifecycle_manager,
             'use_sim_time': use_sim_time

--- a/launch/online_sync_launch.py
+++ b/launch/online_sync_launch.py
@@ -12,6 +12,7 @@ from launch_ros.actions import LifecycleNode
 from launch_ros.event_handlers import OnStateTransition
 from launch_ros.events.lifecycle import ChangeState
 from lifecycle_msgs.msg import Transition
+from launch_ros.descriptions import ParameterFile
 
 
 def generate_launch_description():


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Answer |
| ------ | ----------- |
| Ticket(s) this addresses   | tickets #823|
| Primary OS tested on | Ubuntu 22.04 |
| Robotic platform tested on | - |

---

## Description of contribution in a few bullet points
* add substitution to  `localization`, `online_async`, `online_sync`, `lifelong` launch
* add `slam_params_file` arg to `lifelong` launch
* add `use_sim_time` arg to `lifelong` launch


## Future work that may be required in bullet points
I'm working on the ROS Humble version and would like to have these changes there in the dep package. I don't fully understand how to do this. Do I need to create a separate PR in the `humble` branch or will these changes be ported from `ros2` to `humble` branch later?
