### PR TITLE
Fix map_start_at_dock & map_start_at_dock parsing

### DIFF
--- a/src/slam_toolbox_common.cpp
+++ b/src/slam_toolbox_common.cpp
@@ -637,9 +637,7 @@ bool SlamToolbox::shouldStartWithPoseGraph(
   filename = this->get_parameter("map_file_name").as_string();
   if (!filename.empty()) {
     std::vector<double> read_pose;
-    if (map_start_pose.get_type() == rclcpp::ParameterType::PARAMETER_DOUBLE_ARRAY) {
-      read_pose = map_start_pose.get<std::vector<double>>();
-    }
+    read_pose = map_start_pose.get<std::vector<double>>();
     if (read_pose.size() != 0) {
       // due to the default initialization unset map_start_pose will appear as size 0
       start_at_dock = false;

--- a/src/slam_toolbox_common.cpp
+++ b/src/slam_toolbox_common.cpp
@@ -630,15 +630,18 @@ bool SlamToolbox::shouldStartWithPoseGraph(
   if (!this->has_parameter("map_start_at_dock")) {
     this->declare_parameter("map_start_at_dock", false);
   }
-  auto map_start_at_dock = this->get_parameter("map_start_at_dock").get_parameter_value();
+  start_at_dock = this->get_parameter("map_start_at_dock").as_bool();
   if (!this->has_parameter("map_file_name")) {
     this->declare_parameter("map_file_name", std::string(""));
   }
   filename = this->get_parameter("map_file_name").as_string();
   if (!filename.empty()) {
     std::vector<double> read_pose;
-    if (map_start_pose.get_type() != rclcpp::ParameterType::PARAMETER_NOT_SET) {
+    if (map_start_pose.get_type() == rclcpp::ParameterType::PARAMETER_DOUBLE_ARRAY) {
       read_pose = map_start_pose.get<std::vector<double>>();
+    }
+    if (read_pose.size() != 0) {
+      // due to the default initialization unset map_start_pose will appear as size 0
       start_at_dock = false;
       if (read_pose.size() != 3) {
         RCLCPP_ERROR(get_logger(), "LocalizationSlamToolbox: Incorrect "
@@ -653,9 +656,7 @@ bool SlamToolbox::shouldStartWithPoseGraph(
         q.setRPY(0.0, 0.0, read_pose[2]);
         pose.orientation = tf2::toMsg(q);
       }
-    } else if (map_start_at_dock.get_type() != rclcpp::ParameterType::PARAMETER_NOT_SET) {
-      start_at_dock = map_start_at_dock.get<bool>();
-    } else {
+    } else if (!start_at_dock) {
       RCLCPP_ERROR(get_logger(), "LocalizationSlamToolbox: Map starting "
           "pose not specified. Set either map_start_pose or map_start_at_dock.");
       return false;


### PR DESCRIPTION
Due to the default initialization with declare_parameter the type is never PARAMETER_NOT_SET so change detection of unset map_start_pose by checking for size=0

Fixes #842

tested variants:
- map_start_at_dock unset/false, map_start_pose unset => log error, ok
- map_start_at_dock=unset/false/true, map_start_pose set valid => map_start_pose used, ok
- map_start_at_dock=true => start at first pose, ok
- map_start_pose with only two elements => log error, ok