### PR TITLE
Fix UAF in sync mode during deserialize_map runtime reload

### DIFF
--- a/include/slam_toolbox/slam_toolbox_common.hpp
+++ b/include/slam_toolbox/slam_toolbox_common.hpp
@@ -119,7 +119,10 @@ protected:
   virtual karto::LocalizedRangeScan * addScan(
     karto::LaserRangeFinder * laser, const sensor_msgs::msg::LaserScan::ConstSharedPtr & scan,
     karto::Pose2 & karto_pose);
-  karto::LocalizedRangeScan * addScan(karto::LaserRangeFinder * laser, PosedScan & scanWPose);
+  karto::LocalizedRangeScan * addScan(karto::LaserRangeFinder * laser, PosedScan & scan_w_pose);
+  karto::LocalizedRangeScan * addScanImpl(
+    karto::LaserRangeFinder * laser, const sensor_msgs::msg::LaserScan::ConstSharedPtr & scan,
+    karto::Pose2 & karto_pose);
   bool updateMap();
   tf2::Stamped<tf2::Transform> setTransformFromPoses(
     const karto::Pose2 & pose,

--- a/src/slam_toolbox_common.cpp
+++ b/src/slam_toolbox_common.cpp
@@ -875,18 +875,23 @@ LocalizedRangeScan * SlamToolbox::addScan(
   const sensor_msgs::msg::LaserScan::ConstSharedPtr & scan,
   Pose2 & odom_pose)
 {
-  // Protect the full lifetime of dataset-backed laser/sensor state.
-  // This must cover both getLaser() and getLocalizedRangeScan().
   boost::mutex::scoped_lock lock(smapper_mutex_);
-
   if (!laser) {
-    laser = getLaser(scan);
-    if (!laser) {
-      RCLCPP_WARN(get_logger(), "SlamToolbox: getLaser() failed, ignoring scan.");
-      return nullptr;
-    }
+    RCLCPP_WARN(get_logger(), "SlamToolbox: addScan() called without a laser, "
+      "ignoring scan.");
+    return nullptr;
   }
 
+  return addScanImpl(laser, scan, odom_pose);
+}
+
+/*****************************************************************************/
+LocalizedRangeScan * SlamToolbox::addScanImpl(
+  LaserRangeFinder * laser,
+  const sensor_msgs::msg::LaserScan::ConstSharedPtr & scan,
+  Pose2 & odom_pose)
+/*****************************************************************************/
+{
   // get our localized range scan
   LocalizedRangeScan * range_scan = getLocalizedRangeScan(
     laser, scan, odom_pose);

--- a/src/slam_toolbox_common.cpp
+++ b/src/slam_toolbox_common.cpp
@@ -874,14 +874,23 @@ LocalizedRangeScan * SlamToolbox::addScan(
   LaserRangeFinder * laser,
   const sensor_msgs::msg::LaserScan::ConstSharedPtr & scan,
   Pose2 & odom_pose)
-/*****************************************************************************/
 {
+  // Protect the full lifetime of dataset-backed laser/sensor state.
+  // This must cover both getLaser() and getLocalizedRangeScan().
+  boost::mutex::scoped_lock lock(smapper_mutex_);
+
+  if (!laser) {
+    laser = getLaser(scan);
+    if (!laser) {
+      RCLCPP_WARN(get_logger(), "SlamToolbox: getLaser() failed, ignoring scan.");
+      return nullptr;
+    }
+  }
+
   // get our localized range scan
   LocalizedRangeScan * range_scan = getLocalizedRangeScan(
     laser, scan, odom_pose);
 
-  // Add the localized range scan to the smapper
-  boost::mutex::scoped_lock lock(smapper_mutex_);
   bool processed = false, update_reprocessing_transform = false;
 
   Matrix3 covariance;

--- a/src/slam_toolbox_sync.cpp
+++ b/src/slam_toolbox_sync.cpp
@@ -55,7 +55,16 @@ void SynchronousSlamToolbox::run()
         }
       }
       if (!queue_empty) {
-        addScan(nullptr, scan_w_pose);
+        boost::mutex::scoped_lock lock(smapper_mutex_);
+        LaserRangeFinder * laser = getLaser(scan_w_pose.scan);
+        if (!laser) {
+          RCLCPP_WARN(get_logger(), "SynchronousSlamToolbox: Failed to create laser"
+            " device for %s; discarding scan",
+            scan_w_pose.scan->header.frame_id.c_str());
+          continue;
+        }
+
+        addScanImpl(laser, scan_w_pose.scan, scan_w_pose.pose);
         continue;
       }
     }

--- a/src/slam_toolbox_sync.cpp
+++ b/src/slam_toolbox_sync.cpp
@@ -55,7 +55,7 @@ void SynchronousSlamToolbox::run()
         }
       }
       if (!queue_empty) {
-        addScan(getLaser(scan_w_pose.scan), scan_w_pose);
+        addScan(nullptr, scan_w_pose);
         continue;
       }
     }
@@ -106,7 +106,11 @@ void SynchronousSlamToolbox::laserCallback(
   }
 
   // ensure the laser can be used
-  LaserRangeFinder * laser = getLaser(scan);
+  LaserRangeFinder * laser = nullptr;
+  {
+    boost::mutex::scoped_lock lock(smapper_mutex_);
+    laser = getLaser(scan);
+  }
 
   if (!laser) {
     RCLCPP_WARN(get_logger(), "SynchronousSlamToolbox: Failed to create laser"


### PR DESCRIPTION
---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | Fixes #849 |
| Primary OS tested on | Ubuntu 22.04 |
| Robotic platform tested on | Gazebo simulation |

---

## Description of contribution in a few bullet points

* Moves sync scan processing to resolve laser / localized scan state inside the same `smapper_mutex_` critical section as `addScan()`
* Prevents scan-processing code from observing dataset-backed laser state while `deserialize_map` is clearing and rebuilding runtime mapping state

## Description of documentation updates required from your changes

* It only adjusts internal synchronization during runtime pose graph reload

---

## Future work that may be required in bullet points
