### PR TITLE
Protect clear_queue service with queue mutex

### DIFF
--- a/src/slam_toolbox_sync.cpp
+++ b/src/slam_toolbox_sync.cpp
@@ -128,11 +128,16 @@ bool SynchronousSlamToolbox::clearQueueCallback(
   std::shared_ptr<slam_toolbox::srv::ClearQueue::Response> resp)
 /*****************************************************************************/
 {
-  RCLCPP_INFO(get_logger(), "SynchronousSlamToolbox: "
-    "Clearing all queued scans to add to map.");
+  RCLCPP_INFO(
+    get_logger(),
+    "SynchronousSlamToolbox: Clearing all queued scans to add to map.");
+
+  boost::mutex::scoped_lock lock(q_mutex_);
+
   while (!q_.empty()) {
     q_.pop();
   }
+
   resp->status = true;
   return resp->status;
 }


### PR DESCRIPTION
---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | Fixes #850 |
| Primary OS tested on | Ubuntu 22.04 |
| Robotic platform tested on | Gazebo simulation with synthetic LaserScan + TF setup  |

---

## Description of contribution in a few bullet points

* Protects `SynchronousSlamToolbox::clearQueueCallback()` with `q_mutex_`
* Fixes a race between `/slam_toolbox/clear_queue` and the background `SynchronousSlamToolbox::run()` thread

## Description of documentation updates required from your changes

* It only fixes internal synchronization for the existing `/slam_toolbox/clear_queue` service

---

## Future work that may be required in bullet points
