### PR TITLE
CMake: fix boost system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,7 @@ find_package(Ceres REQUIRED COMPONENTS SuiteSparse)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 add_definitions(-DQT_NO_KEYWORDS)
-find_package(Boost REQUIRED system serialization filesystem thread)
+find_package(Boost REQUIRED serialization filesystem thread)
 
 include_directories(include lib/karto_sdk/include
                             ${EIGEN3_INCLUDE_DIRS}

--- a/lib/karto_sdk/CMakeLists.txt
+++ b/lib/karto_sdk/CMakeLists.txt
@@ -12,7 +12,7 @@ find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)
 find_package(Eigen3 REQUIRED)
-find_package(Boost REQUIRED system serialization filesystem thread)
+find_package(Boost REQUIRED serialization filesystem thread)
 find_package(TBB REQUIRED NO_CMAKE_PACKAGE_REGISTRY)
 
 set(dependencies


### PR DESCRIPTION
Hi,

boost system has been header only since release 1.69 (December 5, 2018), and a useless stub was provided instead.

in 1.89 (August 6, 2025), that stub was removed, so CMake fail if we require it.

ref. https://www.boost.org/doc/libs/latest/libs/system/doc/html/system.html#changes_in_boost_1_89
