### PR TITLE
Completed Manual Loop Closure

### DIFF
--- a/lib/karto_sdk/include/karto_sdk/Mapper.h
+++ b/lib/karto_sdk/include/karto_sdk/Mapper.h
@@ -758,6 +758,14 @@ public:
   kt_bool TryCloseLoop(LocalizedRangeScan * pScan, const Name & rSensorName);
 
   /**
+   * Tries to close a manual loop using the given scan id and pose, also returns the best pose found for the scan
+   * @param id
+   * @param pose
+   * @param bestPoseOut
+   */
+  kt_bool TryCloseManualLoop(const int & id, const Eigen::Vector3d & pose, Eigen::Vector3d & bestPoseOut);
+
+  /**
    * Optimizes scan poses
    */
   void CorrectPoses();
@@ -2079,6 +2087,17 @@ public:
   inline kt_bool TryCloseLoop(LocalizedRangeScan * pScan, const Name & rSensorName)
   {
     return m_pGraph->TryCloseLoop(pScan, rSensorName);
+  }
+
+  /**
+   * Tries to close a manual loop using the given scan id and pose, also returns the best pose found for the scan
+   * @param id
+   * @param pose
+   * @param bestPoseOut
+   */
+  inline kt_bool TryCloseManualLoop(const int & id, const Eigen::Vector3d & pose, Eigen::Vector3d & bestPoseOut)
+  {
+    return m_pGraph->TryCloseManualLoop(id, pose, bestPoseOut);
   }
 
   inline void CorrectPoses()

--- a/lib/karto_sdk/src/Mapper.cpp
+++ b/lib/karto_sdk/src/Mapper.cpp
@@ -1560,6 +1560,92 @@ kt_bool MapperGraph::TryCloseLoop(LocalizedRangeScan * pScan, const Name & rSens
   return loopClosed;
 }
 
+kt_bool MapperGraph::TryCloseManualLoop(const int & id, const Eigen::Vector3d & pose, Eigen::Vector3d & bestPoseOut)
+{
+  kt_bool loopClosed = false;
+
+  kt_int32u scanIndex = 0;
+
+  Pose2 ManualPose(pose(0), pose(1), pose(2));
+
+  LocalizedRangeScan * pScan = m_pMapper->m_pMapperSensorManager->GetScan(id);
+
+  if (pScan == NULL) {
+    return false;
+  }
+
+  Pose2 backupPose = pScan->GetSensorPose();
+  pScan->SetSensorPose(ManualPose);
+  Name rSensorName = pScan->GetSensorName();
+
+  LocalizedRangeScanVector candidateChain = FindPossibleLoopClosure(pScan, rSensorName, scanIndex);
+
+  while (!candidateChain.empty()) {
+    Pose2 bestPose;
+    Matrix3 covariance;
+    kt_double coarseResponse = m_pLoopScanMatcher->MatchScan(pScan, candidateChain,
+        bestPose, covariance, false, false);
+
+    std::stringstream stream;
+    stream << "COARSE RESPONSE: " << coarseResponse <<
+      " (> " << m_pMapper->m_pLoopMatchMinimumResponseCoarse->GetValue() << ")" <<
+      std::endl;
+    stream << "            var: " << covariance(0, 0) << ",  " << covariance(1, 1) <<
+      " (< " << m_pMapper->m_pLoopMatchMaximumVarianceCoarse->GetValue() << ")";
+
+    m_pMapper->FireLoopClosureCheck(stream.str());
+
+    if ((coarseResponse > m_pMapper->m_pLoopMatchMinimumResponseCoarse->GetValue()) &&
+      (covariance(0, 0) < m_pMapper->m_pLoopMatchMaximumVarianceCoarse->GetValue()) &&
+      (covariance(1, 1) < m_pMapper->m_pLoopMatchMaximumVarianceCoarse->GetValue()))
+    {
+      LocalizedRangeScan tmpScan(pScan->GetSensorName(), pScan->GetRangeReadingsVector());
+      tmpScan.SetUniqueId(pScan->GetUniqueId());
+      tmpScan.SetTime(pScan->GetTime());
+      tmpScan.SetStateId(pScan->GetStateId());
+      tmpScan.SetCorrectedPose(pScan->GetCorrectedPose());
+      tmpScan.SetSensorPose(bestPose);    // This also updates OdometricPose.
+      kt_double fineResponse = m_pMapper->m_pSequentialScanMatcher->MatchScan(&tmpScan,
+          candidateChain,
+          bestPose, covariance, false);
+
+      std::stringstream stream1;
+      stream1 << "FINE RESPONSE: " << fineResponse << " (>" <<
+        m_pMapper->m_pLoopMatchMinimumResponseFine->GetValue() << ")" << std::endl;
+      m_pMapper->FireLoopClosureCheck(stream1.str());
+
+      if (fineResponse < m_pMapper->m_pLoopMatchMinimumResponseFine->GetValue()) {
+        m_pMapper->FireLoopClosureCheck("REJECTED!");
+    
+      } else {
+        m_pMapper->FireBeginLoopClosure("Closing Manual loop...");
+
+        pScan->SetSensorPose(bestPose);
+        LinkChainToScan(candidateChain, pScan, bestPose, covariance);
+        CorrectPoses();
+
+        bestPoseOut(0) = bestPose.GetX();
+        bestPoseOut(1) = bestPose.GetY();
+        bestPoseOut(2) = bestPose.GetHeading();
+
+        m_pMapper->FireEndLoopClosure("Manual Loop closed!");
+
+        loopClosed = true;
+      }
+    } else {
+      m_pMapper->FireLoopClosureCheck("REJECTED!");
+    }
+
+    candidateChain = FindPossibleLoopClosure(pScan, rSensorName, scanIndex);
+  }
+
+  if (!loopClosed) {
+    pScan->SetSensorPose(backupPose);
+  }
+
+  return loopClosed;
+}
+
 LocalizedRangeScan * MapperGraph::GetClosestScanToPose(
   const LocalizedRangeScanVector & rScans,
   const Pose2 & rPose) const
@@ -1987,15 +2073,15 @@ LocalizedRangeScanVector MapperGraph::FindPossibleLoopClosure(
     kt_double squaredDistance = candidateScanPose.GetPosition().SquaredDistance(pose.GetPosition());
     if (squaredDistance <
       math::Square(m_pMapper->m_pLoopSearchMaximumDistance->GetValue()) + KT_TOLERANCE)
-    {
-      // a linked scan cannot be in the chain
-      if (find(nearLinkedScans.begin(), nearLinkedScans.end(),
+      {
+        // a linked scan cannot be in the chain
+        if (find(nearLinkedScans.begin(), nearLinkedScans.end(),
         pCandidateScan) != nearLinkedScans.end())
       {
-        chain.clear();
-      } else {
-        chain.push_back(pCandidateScan);
-      }
+          chain.clear();
+        } else {
+          chain.push_back(pCandidateScan);
+        }
     } else {
       // return chain if it is long "enough"
       if (chain.size() >= m_pMapper->m_pLoopMatchMinimumChainSize->GetValue()) {
@@ -2742,12 +2828,12 @@ kt_bool Mapper::Process(LocalizedRangeScan * pScan, Matrix3 * covariance)
 
     // correct scan (if not first scan)
     if (m_pUseScanMatching->GetValue() && pLastScan != NULL) {
-      Pose2 bestPose;
-      m_pSequentialScanMatcher->MatchScan(pScan,
-        m_pMapperSensorManager->GetRunningScans(pScan->GetSensorName()),
+    Pose2 bestPose;
+        m_pSequentialScanMatcher->MatchScan(pScan,
+          m_pMapperSensorManager->GetRunningScans(pScan->GetSensorName()),
         bestPose,
         cov);
-      pScan->SetSensorPose(bestPose);
+        pScan->SetSensorPose(bestPose);
       if (covariance) {
         *covariance = cov;
       }
@@ -2813,12 +2899,12 @@ kt_bool Mapper::ProcessAgainstNodesNearBy(LocalizedRangeScan * pScan, kt_bool ad
 
     // correct scan (if not first scan)
     if (m_pUseScanMatching->GetValue() && pLastScan != NULL) {
-      Pose2 bestPose;
-      m_pSequentialScanMatcher->MatchScan(pScan,
-        m_pMapperSensorManager->GetRunningScans(pScan->GetSensorName()),
+        Pose2 bestPose;
+        m_pSequentialScanMatcher->MatchScan(pScan,
+          m_pMapperSensorManager->GetRunningScans(pScan->GetSensorName()),
         bestPose,
         cov);
-      pScan->SetSensorPose(bestPose);
+        pScan->SetSensorPose(bestPose);
     }
 
     pScan->SetOdometricPose(pScan->GetCorrectedPose());
@@ -2903,12 +2989,12 @@ kt_bool Mapper::ProcessLocalization(LocalizedRangeScan * pScan, Matrix3 * covari
 
   // correct scan (if not first scan)
   if (m_pUseScanMatching->GetValue() && pLastScan != NULL) {
-    Pose2 bestPose;
-    m_pSequentialScanMatcher->MatchScan(pScan,
-      m_pMapperSensorManager->GetRunningScans(pScan->GetSensorName()),
+  Pose2 bestPose;
+      m_pSequentialScanMatcher->MatchScan(pScan,
+        m_pMapperSensorManager->GetRunningScans(pScan->GetSensorName()),
       bestPose,
       cov);
-    pScan->SetSensorPose(bestPose);
+      pScan->SetSensorPose(bestPose);
     if (covariance) {
       *covariance = cov;
     }
@@ -3086,12 +3172,12 @@ kt_bool Mapper::ProcessAgainstNode(
 
     // correct scan (if not first scan)
     if (m_pUseScanMatching->GetValue() && pLastScan != NULL) {
-      Pose2 bestPose;
-      m_pSequentialScanMatcher->MatchScan(pScan,
-        m_pMapperSensorManager->GetRunningScans(pScan->GetSensorName()),
+    Pose2 bestPose;
+        m_pSequentialScanMatcher->MatchScan(pScan,
+          m_pMapperSensorManager->GetRunningScans(pScan->GetSensorName()),
         bestPose,
         cov);
-      pScan->SetSensorPose(bestPose);
+        pScan->SetSensorPose(bestPose);
     }
 
     pScan->SetOdometricPose(pScan->GetCorrectedPose());

--- a/src/loop_closure_assistant.cpp
+++ b/src/loop_closure_assistant.cpp
@@ -298,13 +298,13 @@ bool LoopClosureAssistant::manualLoopClosureCallback(
     std::map<int, Eigen::Vector3d>::const_iterator it = moved_nodes_.begin();
     for (it; it != moved_nodes_.end(); ++it)
     {
-      moveNode(it->first,
-        Eigen::Vector3d(it->second(0),it->second(1), it->second(2)));
+      Eigen::Vector3d bestPoseOut = it->second;
+      if (mapper_->TryCloseManualLoop(it->first, Eigen::Vector3d(it->second(0),it->second(1), it->second(2)), bestPoseOut))
+      {
+        moveNode(it->first, bestPoseOut);
+      }
     }
   }
-
-  // optimize
-  mapper_->CorrectPoses();
 
   //update visualization and clear out nodes completed
   publishGraph();


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | [#70](https://github.com/SteveMacenski/slam_toolbox/issues/70) , [#311 ](https://github.com/SteveMacenski/slam_toolbox/issues/311) ,  [#788](https://github.com/SteveMacenski/slam_toolbox/issues/788) |
| Primary OS tested on | Ubuntu 22.04 |
| Branch | humble |
| Robotic platform tested on | Turtlebot Gazebo Simulation |

---

## Description of contribution in a few bullet points

* I added TryCloseManualLoop() in Karto SDK and called it when a node is moved with interactive markers.
* TryCloseManualLoop() is very similar to TryCloseLoop(), but it accepts the pose of a node from moved_nodes_ and updates the SensorPose of pScan before calling FindPossibleLoopClosures().
* I also made sure to restore the original pose of pScan if the Loop Closure doesn't meet the Coarse and Fine thresholds.
* The Manual Loop Closure works, but I am not very sure if this is the way to build it, So opening this as a Draft PR

Note : There some Custom Debug Logs in the attached video. I haven't included the Debug Logs in this draft PR, I am planning to include it after my [PR for Debug Logs](https://github.com/SteveMacenski/slam_toolbox/pull/857) gets merged.

https://github.com/user-attachments/assets/caf39e04-7625-421c-8acc-0b8431bdd90d


## Description of documentation updates required from your changes
 NIL

---

## Future work that may be required in bullet points
NIL
