### PR TITLE
feat: add validation for Mapper correlation configs to check if it is in normal bound

### DIFF
--- a/lib/karto_sdk/src/Mapper.cpp
+++ b/lib/karto_sdk/src/Mapper.cpp
@@ -474,8 +474,8 @@ ScanMatcher::~ScanMatcher()
   }
 }
 
-const kt_double MIN_MAPPER_VALUE = 1e-4;
-const kt_double MAX_MAPEER_VALUE = 1e+4;
+const kt_double MIN_MAPPER_VALUE = 1e-6;
+const kt_double MAX_MAPEER_VALUE = 1e6;
 
 ScanMatcher * ScanMatcher::Create(
   Mapper * pMapper, kt_double searchSize, kt_double resolution,

--- a/lib/karto_sdk/src/Mapper.cpp
+++ b/lib/karto_sdk/src/Mapper.cpp
@@ -474,22 +474,37 @@ ScanMatcher::~ScanMatcher()
   }
 }
 
+const kt_double MIN_MAPPER_VALUE = 1e-4;
+const kt_double MAX_MAPEER_VALUE = 1e+4;
+
 ScanMatcher * ScanMatcher::Create(
   Mapper * pMapper, kt_double searchSize, kt_double resolution,
   kt_double smearDeviation, kt_double rangeThreshold)
 {
   // invalid parameters
-  if (resolution <= 0) {
-    return NULL;
+  if (resolution < MIN_MAPPER_VALUE || resolution > MAX_MAPEER_VALUE) {
+    std::stringstream error;
+    error << "Invalid resolution " << resolution << " passed to ScanMatcher::Create. Must be between "
+          << MIN_MAPPER_VALUE << " and " << MAX_MAPEER_VALUE << ".";
+    throw std::invalid_argument(error.str());
   }
-  if (searchSize <= 0) {
-    return NULL;
+  if (searchSize < MIN_MAPPER_VALUE || searchSize > MAX_MAPEER_VALUE) {
+    std::stringstream error;
+    error << "Invalid search size " << searchSize << " passed to ScanMatcher::Create. Must be between "
+          << MIN_MAPPER_VALUE << " and " << MAX_MAPEER_VALUE << ".";
+    throw std::invalid_argument(error.str());
   }
-  if (smearDeviation < 0) {
-    return NULL;
+  if (smearDeviation < MIN_MAPPER_VALUE || smearDeviation > MAX_MAPEER_VALUE) {
+    std::stringstream error;
+    error << "Invalid smear deviation " << smearDeviation << " passed to ScanMatcher::Create. Must be between "
+          << MIN_MAPPER_VALUE << " and " << MAX_MAPEER_VALUE << ".";
+    throw std::invalid_argument(error.str());
   }
-  if (rangeThreshold <= 0) {
-    return NULL;
+  if (rangeThreshold < MIN_MAPPER_VALUE || rangeThreshold > MAX_MAPEER_VALUE) {
+    std::stringstream error;
+    error << "Invalid range threshold " << rangeThreshold << " passed to ScanMatcher::Create. Must be between "
+          << MIN_MAPPER_VALUE << " and " << MAX_MAPEER_VALUE << ".";
+    throw std::invalid_argument(error.str());
   }
 
   assert(math::DoubleEqual(math::Round(searchSize / resolution), (searchSize / resolution)));


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | https://github.com/SteveMacenski/slam_toolbox/issues/859 |
| Primary OS tested on | Ubuntu 24.04 |
| Robotic platform tested on | default |

---

## Description of contribution in a few bullet points

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->
* add validation code to check if each correlation values are in normal bound
* set normal bound(`MAX/MIN_MAPPER_VALUE`) to avoid memory-realated erros without any semantic breaking.
* not return NULL, throw runtime error due to wrong configuration of node

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->
* do not need, not affect the documented requirements

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->
* N/A