### PR TITLE
feat:add save_map request name validation to prevent os command injec…

### DIFF
--- a/src/map_saver.cpp
+++ b/src/map_saver.cpp
@@ -18,6 +18,7 @@
 
 #include <memory>
 #include <string>
+#include <regex>
 #include "slam_toolbox/map_saver.hpp"
 
 namespace map_saver
@@ -63,6 +64,15 @@ bool MapSaver::saveMapCallback(
   }
 
   const std::string name = req->name.data;
+
+  // check if name is formmated file path
+  static const std::regex allowed("^[A-Za-z0-9_./-]+$");
+  if (!std::regex_match(name, allowed)) {
+    RCLCPP_ERROR(logger_, "Invalid map file path: %s", name.c_str());
+    response->result = response->RESULT_UNDEFINED_FAILURE;
+    return false;
+  }
+
   std::string set_namespace;
   if (!namespace_str_.empty()) {
     set_namespace = " -r __ns:=" + namespace_str_;


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | https://github.com/SteveMacenski/slam_toolbox/issues/861|
| Primary OS tested on | Ubuntu 24.04 |
| Robotic platform tested on | None |

---

## Description of contribution in a few bullet points

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->
* add validation code to check if the file name in `/save_map` is valid format of file path
* if not, reject received reqeust and response with failure message(`RESULT_UNDEFINED_FAILURE`) 
* prevent OS command injection attack by `system` call with user-controlled inputs (i.e. `req->data.name`)


## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->
* do not need, not affect the documented requirements

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->
* `system` is fundamentally dangerous function in aspect of security.
* I think it is better to use `posix_swanp`(safer than `system`), ROS2 API call or other alternatives.