### PR TITLE
Add clear_max_range param to opt in to REP117 +Inf clearing (#662)

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,8 @@ The following settings and options are exposed to you. My default configuration 
 
 `occupancy_threshold` - Minimum ratio of beams hitting cell to beams passing through cell to be marked as occupied
 
+`clear_max_range` - Per REP117, a laser range of +Inf means "no obstacle detected out to max range" (confirmed free space), while NaN means "no valid data" (unknown). When true, +Inf readings clear free space along the beam out to `max_laser_range`; NaN readings are always ignored regardless of this setting. Default `false` preserves legacy behavior of ignoring both +Inf and NaN identically.
+
 # Install
 
 ROSDep will take care of the major things

--- a/config/mapper_params_lifelong.yaml
+++ b/config/mapper_params_lifelong.yaml
@@ -87,3 +87,10 @@ slam_toolbox:
     use_response_expansion: true
     min_pass_through: 2
     occupancy_threshold: 0.1
+
+    # Per REP117, +Inf laser readings mean "no obstacle out to max range"
+    # (confirmed free space); NaN means "no valid data" (unknown) and is
+    # always ignored regardless of this setting. When true, clear free
+    # space along +Inf beams out to max_laser_range. Default false
+    # preserves legacy behavior of ignoring both +Inf and NaN identically.
+    clear_max_range: false

--- a/config/mapper_params_localization.yaml
+++ b/config/mapper_params_localization.yaml
@@ -70,3 +70,10 @@ slam_toolbox:
     use_response_expansion: true
     min_pass_through: 2
     occupancy_threshold: 0.1
+
+    # Per REP117, +Inf laser readings mean "no obstacle out to max range"
+    # (confirmed free space); NaN means "no valid data" (unknown) and is
+    # always ignored regardless of this setting. When true, clear free
+    # space along +Inf beams out to max_laser_range. Default false
+    # preserves legacy behavior of ignoring both +Inf and NaN identically.
+    clear_max_range: false

--- a/config/mapper_params_offline.yaml
+++ b/config/mapper_params_offline.yaml
@@ -69,3 +69,10 @@ slam_toolbox:
     use_response_expansion: true
     min_pass_through: 2
     occupancy_threshold: 0.1
+
+    # Per REP117, +Inf laser readings mean "no obstacle out to max range"
+    # (confirmed free space); NaN means "no valid data" (unknown) and is
+    # always ignored regardless of this setting. When true, clear free
+    # space along +Inf beams out to max_laser_range. Default false
+    # preserves legacy behavior of ignoring both +Inf and NaN identically.
+    clear_max_range: false

--- a/config/mapper_params_online_async.yaml
+++ b/config/mapper_params_online_async.yaml
@@ -82,6 +82,5 @@ slam_toolbox:
     # (confirmed free space); NaN means "no valid data" (unknown) and is
     # always ignored regardless of this setting. When true, clear free
     # space along +Inf beams out to max_laser_range. Default false
-    # preserves legacy behavior of ignoring both +Inf and NaN identically;
-    # enabled here for local testing.
+    # preserves legacy behavior of ignoring both +Inf and NaN identically.
     clear_max_range: false

--- a/config/mapper_params_online_async.yaml
+++ b/config/mapper_params_online_async.yaml
@@ -77,3 +77,11 @@ slam_toolbox:
     use_response_expansion: true
     min_pass_through: 2
     occupancy_threshold: 0.1
+
+    # Per REP117, +Inf laser readings mean "no obstacle out to max range"
+    # (confirmed free space); NaN means "no valid data" (unknown) and is
+    # always ignored regardless of this setting. When true, clear free
+    # space along +Inf beams out to max_laser_range. Default false
+    # preserves legacy behavior of ignoring both +Inf and NaN identically;
+    # enabled here for local testing.
+    clear_max_range: false

--- a/config/mapper_params_online_sync.yaml
+++ b/config/mapper_params_online_sync.yaml
@@ -77,3 +77,10 @@ slam_toolbox:
     use_response_expansion: true
     min_pass_through: 2
     occupancy_threshold: 0.1
+
+    # Per REP117, +Inf laser readings mean "no obstacle out to max range"
+    # (confirmed free space); NaN means "no valid data" (unknown) and is
+    # always ignored regardless of this setting. When true, clear free
+    # space along +Inf beams out to max_laser_range. Default false
+    # preserves legacy behavior of ignoring both +Inf and NaN identically.
+    clear_max_range: false

--- a/include/slam_toolbox/merge_maps_kinematic.hpp
+++ b/include/slam_toolbox/merge_maps_kinematic.hpp
@@ -105,6 +105,9 @@ private:
   double resolution_;
   int min_pass_through_;
   double occupancy_threshold_;
+  // Opt-in, off by default: see ClearMaxRange param docs (REP117 +Inf
+  // handling) in Mapper.cpp for what this controls.
+  bool clear_max_range_;
   int num_submaps_;
 };
 

--- a/lib/karto_sdk/include/karto_sdk/Karto.h
+++ b/lib/karto_sdk/include/karto_sdk/Karto.h
@@ -5919,6 +5919,7 @@ public:
 
     m_pMinPassThrough = new Parameter<kt_int32u>("MinPassThrough", 2);
     m_pOccupancyThreshold = new Parameter<kt_double>("OccupancyThreshold", 0.1);
+    m_pClearMaxRange = new Parameter<kt_bool>("ClearMaxRange", false);
 
     GetCoordinateConverter()->SetScale(1.0 / resolution);
     GetCoordinateConverter()->SetOffset(rOffset);
@@ -5936,6 +5937,7 @@ public:
 
     delete m_pMinPassThrough;
     delete m_pOccupancyThreshold;
+    delete m_pClearMaxRange;
   }
 
 public:
@@ -5943,10 +5945,12 @@ public:
    * Create an occupancy grid from the given scans using the given resolution
    * @param rScans
    * @param resolution
+   * @param clear_max_range whether to clear free space for +Inf readings
+   * out to the range threshold (see SetClearMaxRange)
    */
   static OccupancyGrid * CreateFromScans(
     const LocalizedRangeScanVector & rScans,
-    kt_double resolution, kt_int32u min_pass_through, kt_double occupancy_threshold)
+    kt_double resolution, kt_int32u min_pass_through, kt_double occupancy_threshold, kt_bool clear_max_range)
   {
     if (rScans.empty()) {
       return NULL;
@@ -5958,6 +5962,7 @@ public:
     OccupancyGrid * pOccupancyGrid = new OccupancyGrid(width, height, offset, resolution);
     pOccupancyGrid->SetMinPassThrough(min_pass_through); 
     pOccupancyGrid->SetOccupancyThreshold(occupancy_threshold); 
+    pOccupancyGrid->SetClearMaxRange(clear_max_range);
     pOccupancyGrid->CreateFromScans(rScans);
 
     return pOccupancyGrid;
@@ -6059,6 +6064,19 @@ public:
     m_pOccupancyThreshold->SetValue(thresh);
   }
 
+  /**
+   * Sets whether +Inf (max range, no obstacle detected per REP117) laser
+   * readings should clear free space out to the range threshold, instead of
+   * being ignored like a NaN (no data) reading. Off by default so existing
+   * behavior/maps are unaffected; NaN readings are always ignored
+   * regardless of this setting.
+   * @param clearMaxRange
+   */
+  void SetClearMaxRange(kt_bool clearMaxRange)
+  {
+    m_pClearMaxRange->SetValue(clearMaxRange);
+  }
+
 protected:
   /**
    * Get cell hit grid
@@ -6151,6 +6169,11 @@ protected:
     kt_double rangeThreshold = laserRangeFinder->GetRangeThreshold();
     kt_double maxRange = laserRangeFinder->GetMaximumRange();
     kt_double minRange = laserRangeFinder->GetMinimumRange();
+    // Needed to recompute a beam's endpoint from scratch when clamping a
+    // +Inf reading below -- see the ClearMaxRange handling in the loop.
+    Pose2 scanPose = pScan->GetSensorPose();
+    kt_double minimumAngle = laserRangeFinder->GetMinimumAngle();
+    kt_double angularResolution = laserRangeFinder->GetAngularResolution();
 
     Vector2<kt_double> scanPosition = pScan->GetSensorPose().GetPosition();
     // get scan point readings
@@ -6166,7 +6189,28 @@ protected:
       kt_double rangeReading = pScan->GetRangeReadings()[pointIndex];
       kt_bool isEndPointValid = rangeReading < (rangeThreshold - KT_TOLERANCE);
 
-      if (rangeReading <= minRange || rangeReading >= maxRange || std::isnan(rangeReading)) {
+      // Per REP117, +Inf means "no obstacle out to max range" (confirmed free
+      // space), while NaN means "no valid data" (unknown) -- NaN is always
+      // ignored below regardless of ClearMaxRange. When opted in, treat a
+      // +Inf reading as a beam that should clear free space out to
+      // rangeThreshold. `point` (from GetPointReadings) is itself +Inf/NaN
+      // for a +Inf rangeReading, so it can't be rescaled like the finite
+      // case below (rangeThreshold / Inf == 0, then 0 * Inf == NaN) --
+      // instead recompute a fresh, finite endpoint directly from the beam's
+      // angle, the same way LocalizedRangeScan::Update() does.
+      kt_bool clampedToThreshold = false;
+      if(m_pClearMaxRange->GetValue() == true){
+        if(std::isinf(rangeReading)){
+          rangeReading = rangeThreshold;
+          clampedToThreshold = true;
+          kt_double angle = scanPose.GetHeading() + minimumAngle + pointIndex * angularResolution;
+          point.SetX(scanPose.GetX() + (rangeReading * cos(angle)));
+          point.SetY(scanPose.GetY() + (rangeReading * sin(angle)));
+        }
+      }
+      if (!clampedToThreshold &&
+        (rangeReading <= minRange || rangeReading >= maxRange || std::isnan(rangeReading)))
+      {
         // ignore these readings
         pointIndex++;
         continue;
@@ -6322,6 +6366,11 @@ private:
 
   // Minimum ratio of beams hitting cell to beams passing through cell to be marked as occupied
   Parameter<kt_double> * m_pOccupancyThreshold;
+
+  // Whether +Inf (confirmed no obstacle out to max range, per REP117) laser
+  // readings clear free space out to the range threshold. Off by default;
+  // NaN (no data) readings are always ignored regardless of this setting.
+  Parameter<kt_bool> * m_pClearMaxRange;
 };    // OccupancyGrid
 
 ////////////////////////////////////////////////////////////////////////////////////////

--- a/lib/karto_sdk/include/karto_sdk/Mapper.h
+++ b/lib/karto_sdk/include/karto_sdk/Mapper.h
@@ -2364,6 +2364,11 @@ protected:
   // Minimum ratio of beams hitting cell to beams passing through cell to be marked as occupied
   Parameter<kt_double> * m_pOccupancyThreshold;
 
+  // Whether +Inf (confirmed no obstacle out to max range, per REP117) laser
+  // readings clear free space out to the range threshold. Off by default;
+  // NaN (no data) readings are always ignored regardless of this setting.
+  Parameter<kt_bool> * m_pClearMaxRange;
+
   friend class boost::serialization::access;
   template<class Archive>
   void serialize(Archive & ar, const unsigned int version)
@@ -2408,9 +2413,10 @@ protected:
     ar & BOOST_SERIALIZATION_NVP(m_pMinimumAnglePenalty);
     ar & BOOST_SERIALIZATION_NVP(m_pMinimumDistancePenalty);
     ar & BOOST_SERIALIZATION_NVP(m_pUseResponseExpansion);
-// NOTE: the following two lines are commented out to avoid breaking the serialization of already existing maps
-//    ar & BOOST_SERIALIZATION_NVP(m_pMinPassThrough); 
+// NOTE: the following three lines are commented out to avoid breaking the serialization of already existing maps
+//    ar & BOOST_SERIALIZATION_NVP(m_pMinPassThrough);
 //    ar & BOOST_SERIALIZATION_NVP(m_pOccupancyThreshold);
+//    ar & BOOST_SERIALIZATION_NVP(m_pClearMaxRange);
     std::cout << "**Finished serializing Mapper**\n";
   }
 
@@ -2457,6 +2463,7 @@ public:
   bool getParamUseResponseExpansion();
   int getParamMinPassThrough();
   double getParamOccupancyThreshold();
+  bool getParamClearMaxRange();
 
   /* Setters */
   // General Parameters
@@ -2497,6 +2504,7 @@ public:
   void setParamUseResponseExpansion(bool b);
   void setParamMinPassThrough(int i);
   void setParamOccupancyThreshold(double d);
+  void setParamClearMaxRange(bool b);
 };
 BOOST_SERIALIZATION_ASSUME_ABSTRACT(Mapper)
 }  // namespace karto

--- a/lib/karto_sdk/src/Mapper.cpp
+++ b/lib/karto_sdk/src/Mapper.cpp
@@ -2318,6 +2318,16 @@ void Mapper::InitializeParameters()
     "OccupancyThreshold",
     "Minimum ratio of beams hitting cell to beams passing through cell to be marked as occupied",
     0.1, GetParameterManager());
+
+  // Per REP117, +Inf readings mean "no obstacle out to max range" (free
+  // space); NaN means "no valid data" and is always ignored regardless of
+  // this setting. Off by default so existing behavior/maps are unaffected.
+  m_pClearMaxRange = new Parameter<kt_bool>(
+    "ClearMaxRange",
+    "Whether to clear free space for +Inf (max range, no obstacle per "
+    "REP117) laser readings out to the range threshold. NaN readings are "
+    "always ignored regardless of this setting.",
+    false, GetParameterManager());
 }
 /* Adding in getters and setters here for easy parameter access */
 
@@ -2489,6 +2499,11 @@ double Mapper::getParamOccupancyThreshold()
   return static_cast<double>(m_pOccupancyThreshold->GetValue());
 }
 
+bool Mapper::getParamClearMaxRange()
+{
+  return static_cast<bool>(m_pClearMaxRange->GetValue());
+}
+
 /* Setters for parameters */
 // General Parameters
 void Mapper::setParamUseScanMatching(bool b)
@@ -2649,6 +2664,11 @@ void Mapper::setParamMinPassThrough(int i)
 void Mapper::setParamOccupancyThreshold(double d)
 {
   m_pOccupancyThreshold->SetValue((kt_double)d);
+}
+
+void Mapper::setParamClearMaxRange(bool b)
+{
+  m_pClearMaxRange->SetValue((kt_bool)b);
 }
 
 

--- a/src/merge_maps_kinematic.cpp
+++ b/src/merge_maps_kinematic.cpp
@@ -37,9 +37,13 @@ void MergeMapsKinematic::configure()
   resolution_ = 0.05;
   min_pass_through_ = 2;
   occupancy_threshold_ = 0.1;
+  // Opt-in, off by default: see ClearMaxRange param docs (REP117 +Inf
+  // handling) in Mapper.cpp for what this controls.
+  clear_max_range_ = false;
   resolution_ = this->declare_parameter("resolution", resolution_);
   min_pass_through_ = this->declare_parameter("min_pass_through", min_pass_through_);
   occupancy_threshold_ = this->declare_parameter("occupancy_threshold", occupancy_threshold_);
+  clear_max_range_ = this->declare_parameter("clear_max_range", false);
   auto qos = rclcpp::QoS(rclcpp::KeepLast(1)).transient_local();
 
   sstS_.push_back(this->create_publisher<nav_msgs::msg::OccupancyGrid>(
@@ -304,7 +308,7 @@ void MergeMapsKinematic::kartoToROSOccupancyGrid(
 /*****************************************************************************/
 {
   OccupancyGrid * occ_grid = NULL;
-  occ_grid = OccupancyGrid::CreateFromScans(scans, resolution_, min_pass_through_, occupancy_threshold_);
+  occ_grid = OccupancyGrid::CreateFromScans(scans, resolution_, min_pass_through_, occupancy_threshold_, clear_max_range_);
   if (!occ_grid) {
     RCLCPP_INFO(get_logger(),
       "MergeMapsKinematic: Could not make occupancy grid.");

--- a/src/slam_mapper.cpp
+++ b/src/slam_mapper.cpp
@@ -66,7 +66,7 @@ karto::OccupancyGrid * SMapper::getOccupancyGrid(const double & resolution)
   karto::OccupancyGrid * occ_grid = nullptr;
   return karto::OccupancyGrid::CreateFromScans(
     mapper_->GetAllProcessedScans(),
-    resolution, (kt_int32u)mapper_->getParamMinPassThrough(), (kt_double)mapper_->getParamOccupancyThreshold());
+    resolution, (kt_int32u)mapper_->getParamMinPassThrough(), (kt_double)mapper_->getParamOccupancyThreshold(), (kt_bool)mapper_->getParamClearMaxRange());
 }
 
 /*****************************************************************************/
@@ -370,6 +370,15 @@ void SMapper::configure(const NodeT & node)
   }
   node->get_parameter("occupancy_threshold", occupancy_threshold);
   mapper_->setParamOccupancyThreshold(occupancy_threshold);
+
+  // Opt-in, off by default: see ClearMaxRange param docs (REP117 +Inf
+  // handling) in Mapper.cpp for what this controls.
+  bool clear_max_range = false;
+  if (!node->has_parameter("clear_max_range")) {
+    node->declare_parameter("clear_max_range", clear_max_range);
+  }
+  node->get_parameter("clear_max_range", clear_max_range);
+  mapper_->setParamClearMaxRange(clear_max_range);
 }
 
 /*****************************************************************************/


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #662 |
| Primary OS tested on | Ubuntu 24.04.4 LTS (Noble Numbat) |
| Robotic platform tested on | Gazebo (Harmonic, gz-sim 8.11.0) simulation of TurtleBot3 Waffle |

---

## Description of contribution in a few bullet points

* Per REP117, a `+Inf` laser reading means confirmed free space out to max range, while `NaN` means no data, previously both were treated identically and ignored when building the occupancy grid.
* Added an opt-in `clear_max_range` parameter (default `false`, preserving existing behavior) to `Mapper`/`OccupancyGrid` in the Karto SDK. When enabled, `+Inf` readings clear free space along the beam out to `max_laser_range`; `NaN` readings are still always ignored regardless of this setting.
* Wired the new parameter through `SMapper::configure` (slam_toolbox node) and `MergeMapsKinematic` so it's configurable via ROS parameters in both the online SLAM node and the map-merging tool.
* Followed the existing pattern of excluding new `Mapper` parameters from Boost serialization (see the `m_pMinPassThrough`/`m_pOccupancyThreshold` precedent) to avoid breaking deserialization of existing `.posegraph` files.

**Test setup:** TurtleBot3 Waffle (lidar `max_laser_range` reduced to `5.0` in the SDF for
demo purposes) inside a custom rhombus-shaped Gazebo world,
built from 4 wall segments connecting corners at `(3,0)`, `(0,10)`, `(-3,0)`, `(0,-10)`. The
robot spawns at `(0, 5)`, off-center so the near walls sit well within lidar range while the far
corners sit beyond it — producing `+Inf` beams in the open directions. Screenshots below show
the same scan processed with `clear_max_range` off vs. on.

**`clear_max_range: false` (default, legacy behavior):**
<img width="543" height="684" alt="cl_false1" src="https://github.com/user-attachments/assets/b2c377dd-08c4-4c15-b387-843dde12bef0" />
**`clear_max_range: true`:**
<img width="543" height="684" alt="cl1" src="https://github.com/user-attachments/assets/bd090b04-7d27-4b30-93f0-d032531e127c" />

## Description of documentation updates required from your changes

* Documented the new `clear_max_range` parameter in `README.md` under the parameter reference section.
* Added `clear_max_range: false` with an explanatory comment to all five default config files (`mapper_params_lifelong.yaml`, `mapper_params_localization.yaml`, `mapper_params_offline.yaml`, `mapper_params_online_async.yaml`, `mapper_params_online_sync.yaml`) so the new option is discoverable and defaults are explicit.

---

## Future work that may be required in bullet points

* None anticipated — this is an opt-in, off-by-default addition with no change to existing default behavior.
