### PR TITLE
rviz plugin: transform initial pose into map frame before using it (#863)

### DIFF
--- a/rviz_plugin/slam_toolbox_rviz_plugin.cpp
+++ b/rviz_plugin/slam_toolbox_rviz_plugin.cpp
@@ -264,7 +264,8 @@ void SlamToolboxPlugin::InitialPoseCallback(
   RCLCPP_INFO(
     ros_node_->get_logger(),
     "Setting initial pose from rviz; you can now deserialize a map given that pose.");
-
+  
+  // msg must be in map_frame_, so transform if msg arrived in a different frame
   std::string fixed_frame = msg->header.frame_id;
   geometry_msgs::msg::PoseStamped pose_in, pose_out;
   pose_out.pose = msg->pose.pose;

--- a/rviz_plugin/slam_toolbox_rviz_plugin.cpp
+++ b/rviz_plugin/slam_toolbox_rviz_plugin.cpp
@@ -52,9 +52,9 @@ SlamToolboxPlugin::SlamToolboxPlugin(QWidget * parent)
   interactive = ros_node_->declare_parameter(
     "slam_toolbox/interactive_mode", interactive);
 
-    tf_buffer_ = std::make_shared<tf2_ros::Buffer>(ros_node_->get_clock());
-    tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
-    _initialposeSub =
+  tf_buffer_ = std::make_shared<tf2_ros::Buffer>(ros_node_->get_clock());
+  tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
+  _initialposeSub =
     ros_node_->create_subscription<geometry_msgs::msg::PoseWithCovarianceStamped>(
     "initialpose", 10,
     std::bind(&SlamToolboxPlugin::InitialPoseCallback, this, std::placeholders::_1));
@@ -264,20 +264,20 @@ void SlamToolboxPlugin::InitialPoseCallback(
   RCLCPP_INFO(
     ros_node_->get_logger(),
     "Setting initial pose from rviz; you can now deserialize a map given that pose.");
-  
+
   std::string fixed_frame = msg->header.frame_id;
   geometry_msgs::msg::PoseStamped pose_in, pose_out;
   pose_out.pose = msg->pose.pose;
   if (fixed_frame != map_frame_) {
-      pose_in.header = msg->header;
-      pose_in.pose = msg->pose.pose;
-      try {
-        tf_buffer_->transform(pose_in, pose_out, map_frame_, tf2::durationFromSec(0.5));
-      } catch (const tf2::TransformException & ex) {
-        RCLCPP_ERROR(ros_node_->get_logger(),
-          "InitialPoseCallback: could not transform pose from %s to %s: %s",
-          msg->header.frame_id.c_str(), map_frame_.c_str(), ex.what());
-        return;
+    pose_in.header = msg->header;
+    pose_in.pose = msg->pose.pose;
+    try {
+      tf_buffer_->transform(pose_in, pose_out, map_frame_, tf2::durationFromSec(0.5));
+    } catch (const tf2::TransformException & ex) {
+      RCLCPP_ERROR(ros_node_->get_logger(),
+        "InitialPoseCallback: could not transform pose from %s to %s: %s",
+        msg->header.frame_id.c_str(), map_frame_.c_str(), ex.what());
+      return;
     }
   }
 
@@ -285,7 +285,7 @@ void SlamToolboxPlugin::InitialPoseCallback(
   _line5->setText(QString::number(pose_out.pose.position.x, 'f', 2));
   _line6->setText(QString::number(pose_out.pose.position.y, 'f', 2));
   tf2::Quaternion quat_tf;
-  tf2::convert(pose_out.pose.orientation , quat_tf);
+  tf2::convert(pose_out.pose.orientation, quat_tf);
   tf2::Matrix3x3 m(quat_tf);
   double roll, pitch, yaw;
   m.getRPY(roll, pitch, yaw);

--- a/rviz_plugin/slam_toolbox_rviz_plugin.cpp
+++ b/rviz_plugin/slam_toolbox_rviz_plugin.cpp
@@ -52,7 +52,9 @@ SlamToolboxPlugin::SlamToolboxPlugin(QWidget * parent)
   interactive = ros_node_->declare_parameter(
     "slam_toolbox/interactive_mode", interactive);
 
-  _initialposeSub =
+    tf_buffer_ = std::make_shared<tf2_ros::Buffer>(ros_node_->get_clock());
+    tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
+    _initialposeSub =
     ros_node_->create_subscription<geometry_msgs::msg::PoseWithCovarianceStamped>(
     "initialpose", 10,
     std::bind(&SlamToolboxPlugin::InitialPoseCallback, this, std::placeholders::_1));
@@ -262,11 +264,28 @@ void SlamToolboxPlugin::InitialPoseCallback(
   RCLCPP_INFO(
     ros_node_->get_logger(),
     "Setting initial pose from rviz; you can now deserialize a map given that pose.");
+  
+  std::string fixed_frame = msg->header.frame_id;
+  geometry_msgs::msg::PoseStamped pose_in, pose_out;
+  pose_out.pose = msg->pose.pose;
+  if (fixed_frame != map_frame_) {
+      pose_in.header = msg->header;
+      pose_in.pose = msg->pose.pose;
+      try {
+        tf_buffer_->transform(pose_in, pose_out, map_frame_, tf2::durationFromSec(0.5));
+      } catch (const tf2::TransformException & ex) {
+        RCLCPP_ERROR(ros_node_->get_logger(),
+          "InitialPoseCallback: could not transform pose from %s to %s: %s",
+          msg->header.frame_id.c_str(), map_frame_.c_str(), ex.what());
+        return;
+    }
+  }
+
   _radio2->setChecked(true);
-  _line5->setText(QString::number(msg->pose.pose.position.x, 'f', 2));
-  _line6->setText(QString::number(msg->pose.pose.position.y, 'f', 2));
+  _line5->setText(QString::number(pose_out.pose.position.x, 'f', 2));
+  _line6->setText(QString::number(pose_out.pose.position.y, 'f', 2));
   tf2::Quaternion quat_tf;
-  tf2::convert(msg->pose.pose.orientation , quat_tf);
+  tf2::convert(pose_out.pose.orientation , quat_tf);
   tf2::Matrix3x3 m(quat_tf);
   double roll, pitch, yaw;
   m.getRPY(roll, pitch, yaw);
@@ -557,7 +576,7 @@ void SlamToolboxPlugin::updateCheckStateIfExternalChange()
 
   while (rclcpp::ok()) {
     auto parameters = parameters_client->get_parameters(
-      {"paused_new_measurements", "interactive_mode"}, std::chrono::seconds(1));
+      {"paused_new_measurements", "interactive_mode", "map_frame"}, std::chrono::seconds(1));
     if (parameters.empty()) {
       RCLCPP_INFO_THROTTLE(
         ros_node_->get_logger(), *ros_node_->get_clock(), 5000,
@@ -571,7 +590,7 @@ void SlamToolboxPlugin::updateCheckStateIfExternalChange()
 
       paused_measure = parameters[0].as_bool();
       interactive = parameters[1].as_bool();
-
+      map_frame_ = parameters[2].as_string();
       bool oldState = _check1->blockSignals(true);
       _check1->setChecked(interactive);
       _check1->blockSignals(oldState);

--- a/rviz_plugin/slam_toolbox_rviz_plugin.hpp
+++ b/rviz_plugin/slam_toolbox_rviz_plugin.hpp
@@ -41,6 +41,8 @@
 #include "rviz_common/panel.hpp"
 #include "slam_toolbox/toolbox_msgs.hpp"
 #include "geometry_msgs/msg/pose_with_covariance_stamped.hpp"
+#include "tf2_ros/transform_listener.h"
+#include "tf2_ros/buffer.h"
 #include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
 
 class QLineEdit;
@@ -151,6 +153,9 @@ protected:
   rclcpp::Client<slam_toolbox::srv::DeserializePoseGraph>::SharedPtr _load_map;
 
   std::unique_ptr<std::thread> _thread;
+  std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
+  std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
+  std::string map_frame_;
 
   ContinueMappingType _match_type;
   

--- a/src/slam_toolbox_localization.cpp
+++ b/src/slam_toolbox_localization.cpp
@@ -249,13 +249,30 @@ void LocalizationSlamToolbox::localizePoseCallback(
     return;
   }
 
+  // process_near_pose_ must be in map_frame_, so transform if msg arrived in a different frame
+  std::string fixed_frame = msg->header.frame_id;
+  geometry_msgs::msg::PoseStamped pose_in, pose_out;
+  pose_out.pose = msg->pose.pose;
+  if (fixed_frame != map_frame_) {
+    pose_in.header = msg->header;
+    pose_in.pose = msg->pose.pose;
+    try {
+      tf_->transform(pose_in, pose_out, map_frame_, tf2::durationFromSec(0.5));
+    } catch (const tf2::TransformException & ex) {
+      RCLCPP_ERROR(get_logger(),
+        "LocalizePoseCallback: could not transform pose from %s to %s: %s",
+        msg->header.frame_id.c_str(), map_frame_.c_str(), ex.what());
+      return;
+    }
+  }
+
   boost::mutex::scoped_lock l(pose_mutex_);
   if (process_near_pose_) {
-    process_near_pose_.reset(new Pose2(msg->pose.pose.position.x,
-      msg->pose.pose.position.y, tf2::getYaw(msg->pose.pose.orientation)));
+    process_near_pose_.reset(new Pose2(pose_out.pose.position.x,
+      pose_out.pose.position.y, tf2::getYaw(pose_out.pose.orientation)));
   } else {
-    process_near_pose_ = std::make_unique<Pose2>(msg->pose.pose.position.x,
-        msg->pose.pose.position.y, tf2::getYaw(msg->pose.pose.orientation));
+    process_near_pose_ = std::make_unique<Pose2>(pose_out.pose.position.x,
+        pose_out.pose.position.y, tf2::getYaw(pose_out.pose.orientation));
   }
 
   first_measurement_ = true;
@@ -265,8 +282,8 @@ void LocalizationSlamToolbox::localizePoseCallback(
 
   RCLCPP_INFO(get_logger(),
     "LocalizePoseCallback: Localizing to: (%0.2f %0.2f), theta=%0.2f",
-    msg->pose.pose.position.x, msg->pose.pose.position.y,
-    tf2::getYaw(msg->pose.pose.orientation));
+    pose_out.pose.position.x, pose_out.pose.position.y,
+    tf2::getYaw(pose_out.pose.orientation));
 }
 
 }  // namespace slam_toolbox


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #863 |
| Primary OS tested on | Ubuntu 24.04.4 LTS (Noble Numbat) |
| Branch | jazzy |
| Robotic platform tested on | Gazebo, TurtleBot3 |

---

## Description of contribution in a few bullet points

* Added a condition to  check the frame_id of incoming msg in the subscriber callback function InitialPoseCallback. If it doesn't match the map frame, added a tf transform line to transform msg pose from the frame_id to map frame.
* map_frame is obtained from the slam toolbox's parameters. There is a precedent for this in updateCheckStateIfExternalChange, to which i added map_frame. I had to define the map_frame attribute for the SlamToolboxPlugin class.
* My approach to transform was to add a tf_buffer and tf_listener to the plugin class, which is also a ros node. Not fully sure this is structurally the right way to do it. Plugin owning its own tf buffer felt a little heavy, not sure if there's something in rviz's frame manager I should be using instead.

Tested manually (turtlebot3 gazebo + localization launch):
* Built a map first: turtlebot3 gazebo + online_async_launch.py, drove it around, serialized the map.
* Ran localization_launch.py against that map, but added a static transform (world→map, offset by 5m) so rviz's Fixed Frame (world) would differ from slam_toolbox's map_frame.
*  Set rviz Fixed Frame to world, used "2D Pose Estimate" and clicked at the map's actual origin.
*  Before the fix: panel showed ~(5.09, 0.12) which is off by the static transform's offset. After the fix: ~(0.10, 0.19).

Before:
<img width="1920" height="945" alt="before_frame_id_check" src="https://github.com/user-attachments/assets/f3982010-9e1d-4620-af91-307d97c29b2a" />

After:
<img width="1920" height="945" alt="after_frame_id_check" src="https://github.com/user-attachments/assets/0c70b4c2-2c17-455c-b7b8-2a5b5fc73ed6" />


## Description of documentation updates required from your changes
NA

---

## Future work that may be required in bullet points
*  map_frame_ comes from a background thread polling the slam_toolbox node's parameters once a second. Wanted feedback on direction before going further.

