### PR TITLE
Improve Windows portability

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,11 @@ if(NOT CMAKE_CXX_STANDARD)
 endif()
 cmake_policy(SET CMP0077 NEW)
 
+if(MSVC)
+  add_compile_definitions(_USE_MATH_DEFINES)
+  set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+endif()
+
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/CMake/")
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/lib/karto_sdk/cmake)
 
@@ -271,6 +276,19 @@ add_library(map_and_localization_slam_toolbox src/experimental/slam_toolbox_map_
 target_link_libraries(map_and_localization_slam_toolbox localization_slam_toolbox toolbox_common kartoSlamToolbox ${Boost_LIBRARIES})
 add_executable(map_and_localization_slam_toolbox_node src/experimental/slam_toolbox_map_and_localization_node.cpp)
 target_link_libraries(map_and_localization_slam_toolbox_node map_and_localization_slam_toolbox)
+
+if(MSVC)
+  foreach(
+    target
+    decentralized_multirobot_slam_toolbox_node
+    async_slam_toolbox_node
+    sync_slam_toolbox_node
+    localization_slam_toolbox_node
+    lifelong_slam_toolbox_node
+    map_and_localization_slam_toolbox_node)
+    target_compile_options(${target} PRIVATE /F40000000)
+  endforeach()
+endif()
 
 #### Merging maps tool
 add_executable(merge_maps_kinematic src/merge_maps_kinematic.cpp)

--- a/include/slam_toolbox/merge_maps_kinematic.hpp
+++ b/include/slam_toolbox/merge_maps_kinematic.hpp
@@ -21,7 +21,9 @@
 
 #include <thread>
 #include <sys/stat.h>
+#ifndef _WIN32
 #include <unistd.h>
+#endif
 #include <string>
 #include <map>
 #include <memory>

--- a/include/slam_toolbox/slam_toolbox_common.hpp
+++ b/include/slam_toolbox/slam_toolbox_common.hpp
@@ -19,7 +19,9 @@
 #ifndef SLAM_TOOLBOX__SLAM_TOOLBOX_COMMON_HPP_
 #define SLAM_TOOLBOX__SLAM_TOOLBOX_COMMON_HPP_
 
+#ifndef _WIN32
 #include <sys/resource.h>
+#endif
 #include <boost/thread.hpp>
 #include <string>
 #include <map>

--- a/lib/karto_sdk/CMakeLists.txt
+++ b/lib/karto_sdk/CMakeLists.txt
@@ -5,7 +5,9 @@ if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 17)
 endif()
 set(CMAKE_BUILD_TYPE Release) #None, Debug, Release, RelWithDebInfo, MinSizeRel
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ftemplate-backtrace-limit=0")
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ftemplate-backtrace-limit=0")
+endif()
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
 
 find_package(ament_cmake REQUIRED)
@@ -30,6 +32,7 @@ add_definitions(${EIGEN3_DEFINITIONS})
 
 include_directories(include ${EIGEN3_INCLUDE_DIRS} ${TBB_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
 add_library(kartoSlamToolbox SHARED src/Karto.cpp src/Mapper.cpp)
+target_compile_definitions(kartoSlamToolbox PRIVATE KARTO_DYNAMIC)
 target_link_libraries(kartoSlamToolbox PUBLIC
   rclcpp::rclcpp
   rclcpp_lifecycle::rclcpp_lifecycle

--- a/lib/karto_sdk/src/Mapper.cpp
+++ b/lib/karto_sdk/src/Mapper.cpp
@@ -405,7 +405,7 @@ void MapperSensorManager::SetRunningScanBufferSize(kt_int32u rScanBufferSize)
   m_RunningBufferMaximumSize = rScanBufferSize;
 
   std::vector<Name> names = GetSensorNames();
-  for (uint i = 0; i != names.size(); i++) {
+  for (unsigned int i = 0; i != names.size(); i++) {
     GetScanManager(names[i])->SetRunningScanBufferSize(rScanBufferSize);
   }
 }
@@ -415,7 +415,7 @@ void MapperSensorManager::SetRunningScanBufferMaximumDistance(kt_double rScanBuf
   m_RunningBufferMaximumDistance = rScanBufferMaxDistance;
 
   std::vector<Name> names = GetSensorNames();
-  for (uint i = 0; i != names.size(); i++) {
+  for (unsigned int i = 0; i != names.size(); i++) {
     GetScanManager(names[i])->SetRunningScanBufferMaximumDistance(rScanBufferMaxDistance);
   }
 }
@@ -1883,7 +1883,7 @@ std::vector<Vertex<LocalizedRangeScan> *> MapperGraph::FindNearByVertices(
 
   std::vector<Vertex<LocalizedRangeScan> *> rtn_vertices;
   rtn_vertices.reserve(ret_matches.size());
-  for (uint i = 0; i != ret_matches.size(); i++) {
+  for (unsigned int i = 0; i != ret_matches.size(); i++) {
     rtn_vertices.push_back(vertices_to_search[ret_matches[i].first]);
   }
   return rtn_vertices;
@@ -3004,7 +3004,7 @@ void Mapper::ClearLocalizationBuffer()
   }
 
   std::vector<Name> names = m_pMapperSensorManager->GetSensorNames();
-  for (uint i = 0; i != names.size(); i++)
+  for (unsigned int i = 0; i != names.size(); i++)
   {
     m_pMapperSensorManager->ClearRunningScans(names[i]);
     m_pMapperSensorManager->ClearLastScan(names[i]);

--- a/rviz_plugin/slam_toolbox_rviz_plugin.hpp
+++ b/rviz_plugin/slam_toolbox_rviz_plugin.hpp
@@ -32,6 +32,11 @@
 #include <QLabel>
 #include <QFrame>
 #include <QRadioButton>
+#if defined(_WIN32) && defined(NO_ERROR)
+#pragma push_macro("NO_ERROR")
+#undef NO_ERROR
+#define SLAM_TOOLBOX_RESTORE_NO_ERROR_MACRO
+#endif
 // STL
 #include <thread>
 #include <chrono>
@@ -160,5 +165,10 @@ protected:
 };
 
 }  // namespace slam_toolbox
+
+#ifdef SLAM_TOOLBOX_RESTORE_NO_ERROR_MACRO
+#pragma pop_macro("NO_ERROR")
+#undef SLAM_TOOLBOX_RESTORE_NO_ERROR_MACRO
+#endif
 
 #endif  // RVIZ_PLUGIN__SLAM_TOOLBOX_RVIZ_PLUGIN_H_

--- a/src/merge_maps_kinematic.cpp
+++ b/src/merge_maps_kinematic.cpp
@@ -16,6 +16,7 @@
 
 /* Author: Steven Macenski */
 
+#include <chrono>
 #include <memory>
 #include <utility>
 #include "slam_toolbox/merge_maps_kinematic.hpp"
@@ -105,7 +106,7 @@ bool MergeMapsKinematic::addSubmapCallback(
       "/map_" + std::to_string(num_submaps_), rclcpp::QoS(1)));
   sstmS_.push_back(this->create_publisher<nav_msgs::msg::MapMetaData>(
       "/map_metadata_" + std::to_string(num_submaps_), rclcpp::QoS(1)));
-  sleep(1.0);
+  std::this_thread::sleep_for(std::chrono::seconds(1));
 
   nav_msgs::srv::GetMap::Response map;
   nav_msgs::msg::OccupancyGrid & og = map.map;

--- a/src/slam_toolbox_common.cpp
+++ b/src/slam_toolbox_common.cpp
@@ -53,6 +53,14 @@ SlamToolbox::SlamToolbox(rclcpp::NodeOptions options)
     this->declare_parameter(
       "stack_size_to_use", rclcpp::ParameterType::PARAMETER_INTEGER, descriptor);
     if (this->get_parameter("stack_size_to_use", stack_size)) {
+#ifdef _WIN32
+      if (stack_size != 40'000'000) {
+        RCLCPP_WARN(
+          get_logger(),
+          "Dynamic stack size configuration is unavailable on Windows; "
+          "node was built with stack size 40000000");
+      }
+#else
       RCLCPP_INFO(get_logger(), "Node using stack size %i", (int)stack_size);
       const rlim_t max_stack_size = stack_size;
       struct rlimit stack_limit;
@@ -61,6 +69,7 @@ SlamToolbox::SlamToolbox(rclcpp::NodeOptions options)
         stack_limit.rlim_cur = stack_size;
       }
       setrlimit(RLIMIT_STACK, &stack_limit);
+#endif
     }
   }
   // server side never times out from lifecycle manager


### PR DESCRIPTION
This is part of an effort to contribute RoboStack downstream patches back upstream.

Origin: RoboStack patch/ros-rolling-slam-toolbox.win.patch, authored by Daisuke Nishimatsu.

This carries the current Windows portability pieces from the RoboStack patch: guard POSIX-only headers and stack-limit calls, use std::this_thread::sleep_for instead of POSIX sleep, avoid GCC-only flags on MSVC, enable Windows DLL symbol export generation, define the Karto export macro while building Karto, and replace non-standard uint loop variables with unsigned int.

The message_filters include update from the RoboStack patch is not included because the ros2 branch already has the .hpp include.