### PR TITLE
Initial runtime_disable_scan_matching

### DIFF
--- a/include/slam_toolbox/slam_toolbox_common.hpp
+++ b/include/slam_toolbox/slam_toolbox_common.hpp
@@ -28,6 +28,7 @@
 #include <cstdlib>
 #include <memory>
 #include <fstream>
+#include <atomic>
 
 #include "lifecycle_msgs/msg/state.hpp"
 #include "rclcpp/rclcpp.hpp"
@@ -89,6 +90,7 @@ protected:
   void setParams();
   void setSolver();
   void setROSInterfaces();
+  void updateScanMatchingState();
 
   // callbacks
   virtual void laserCallback(sensor_msgs::msg::LaserScan::ConstSharedPtr scan) = 0;
@@ -176,6 +178,9 @@ protected:
   bool first_measurement_, enable_interactive_mode_;
   bool restamp_tf_;
   bool check_min_dist_and_heading_precisely_;
+  std::atomic_bool runtime_disable_scan_matching_{false};
+  rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr
+    parameter_callback_;
 
   // Book keeping
   std::unique_ptr<mapper_utils::SMapper> smapper_;

--- a/lib/karto_sdk/src/Mapper.cpp
+++ b/lib/karto_sdk/src/Mapper.cpp
@@ -2775,6 +2775,11 @@ kt_bool Mapper::Process(LocalizedRangeScan * pScan, Matrix3 * covariance)
           m_pGraph->TryCloseLoop(pScan, *iter);
         }
       }
+    } else {
+      // Keep running context aligned with odometric scans so re-enabling
+      // scan matching does not immediately correlate against stale history.
+      m_pMapperSensorManager->ClearRunningScans(pScan->GetSensorName());
+      m_pMapperSensorManager->AddRunningScan(pScan);
     }
 
     m_pMapperSensorManager->SetLastScan(pScan);
@@ -2851,6 +2856,11 @@ kt_bool Mapper::ProcessAgainstNodesNearBy(LocalizedRangeScan * pScan, kt_bool ad
           m_pGraph->TryCloseLoop(pScan, *iter);
         }
       }
+    } else {
+      // Keep running context aligned with odometric scans so re-enabling
+      // scan matching does not immediately correlate against stale history.
+      m_pMapperSensorManager->ClearRunningScans(pScan->GetSensorName());
+      m_pMapperSensorManager->AddRunningScan(pScan);
     }
 
     m_pMapperSensorManager->SetLastScan(pScan);
@@ -2937,6 +2947,11 @@ kt_bool Mapper::ProcessLocalization(LocalizedRangeScan * pScan, Matrix3 * covari
         m_pGraph->TryCloseLoop(pScan, *iter);
       }
     }
+  } else {
+    // Keep running context aligned with odometric scans so re-enabling
+    // scan matching does not immediately correlate against stale history.
+    m_pMapperSensorManager->ClearRunningScans(pScan->GetSensorName());
+    m_pMapperSensorManager->AddRunningScan(pScan);
   }
 
   m_pMapperSensorManager->SetLastScan(pScan);
@@ -3122,6 +3137,11 @@ kt_bool Mapper::ProcessAgainstNode(
           m_pGraph->TryCloseLoop(pScan, *iter);
         }
       }
+    } else {
+      // Keep running context aligned with odometric scans so re-enabling
+      // scan matching does not immediately correlate against stale history.
+      m_pMapperSensorManager->ClearRunningScans(pScan->GetSensorName());
+      m_pMapperSensorManager->AddRunningScan(pScan);
     }
 
     m_pMapperSensorManager->SetLastScan(pScan);

--- a/src/slam_toolbox_common.cpp
+++ b/src/slam_toolbox_common.cpp
@@ -432,6 +432,50 @@ void SlamToolbox::setParams()
     this->declare_parameter("paused_new_measurements", false);
   }
   this->set_parameter(rclcpp::Parameter("paused_new_measurements", false));
+
+  if (!this->has_parameter("runtime_disable_scan_matching")) {
+    this->declare_parameter("runtime_disable_scan_matching", false);
+  }
+  runtime_disable_scan_matching_ =
+    this->get_parameter("runtime_disable_scan_matching").as_bool();
+  RCLCPP_INFO(get_logger(), "Runtime scan matching %s",
+    runtime_disable_scan_matching_ ? "disabled" : "enabled");
+
+  updateScanMatchingState();
+
+  parameter_callback_ =
+    this->add_on_set_parameters_callback(
+    [this](const std::vector<rclcpp::Parameter> & params)
+    {
+      rcl_interfaces::msg::SetParametersResult result;
+      result.successful = true;
+
+      for (const auto & p : params) {
+        if (p.get_name() == "runtime_disable_scan_matching") {
+          runtime_disable_scan_matching_ = p.as_bool();
+          RCLCPP_INFO(get_logger(), "Runtime scan matching %s",
+            runtime_disable_scan_matching_ ? "disabled" : "enabled");
+          updateScanMatchingState();
+        }
+      }
+
+      return result;
+    });
+}
+
+/*****************************************************************************/
+void SlamToolbox::updateScanMatchingState()
+/*****************************************************************************/
+{
+  bool use_scan_matching = true;
+  if (this->has_parameter("use_scan_matching")) {
+    use_scan_matching = this->get_parameter("use_scan_matching").as_bool();
+  }
+
+  if (smapper_ && smapper_->getMapper()) {
+    smapper_->getMapper()->setParamUseScanMatching(
+      use_scan_matching && !runtime_disable_scan_matching_);
+  }
 }
 
 /*****************************************************************************/


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (add tickets here #1) |
| Primary OS tested on | (Ubuntu |
| Robotic platform tested on | gazebo simulation of ackerman RC car |

---

## Description of contribution in a few bullet points

* I added a dynamic parameter to disable scan_matching in ROIs.
* `ros2 param set /slam_toolbox runtime_disable_scan_matching true`
  * SLAM will continue mapping with odometry.
* `ros2 param set /slam_toolbox runtime_disable_scan_matching false`
  * SLAM will continue mapping with scan matching and localization corrections.
* The purpose is to prevent SLAM from causing false pose updates in ambiguous corridors or curves with no features.

## Description of documentation updates required from your changes

* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them

---

## Future work that may be required in bullet points

* Further testing in gazebo with different timings of disabling and enabling scan matching
* Merge into the latest branches (not just jazzy)
