### PR TITLE
[jazzy] Reset PausedState on lifecycle configure

### DIFF
--- a/include/slam_toolbox/toolbox_types.hpp
+++ b/include/slam_toolbox/toolbox_types.hpp
@@ -95,6 +95,13 @@ struct PausedState
 {
   PausedState()
   {
+    reset();
+  }
+
+  // Return every application to unpaused.
+  void reset()
+  {
+    boost::mutex::scoped_lock lock(pause_mutex_);
     state_map_[NEW_MEASUREMENTS] = false;
     state_map_[VISUALIZING_GRAPH] = false;
     state_map_[PROCESSING] = false;

--- a/src/slam_toolbox_common.cpp
+++ b/src/slam_toolbox_common.cpp
@@ -103,6 +103,9 @@ CallbackReturn SlamToolbox::on_configure(const rclcpp_lifecycle::State &)
   processor_type_ = PROCESS;
   first_measurement_ = true;
   process_near_pose_ = nullptr;
+  // Pause flags are per-session. Stale ones desync from the parameters
+  // republished below and by LoopClosureAssistant.
+  state_.reset();
   smapper_ = std::make_unique<mapper_utils::SMapper>();
   dataset_ = std::make_unique<Dataset>();
 


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses | #884 |
| Primary OS tested on | Ubuntu 24.04 (`ros:jazzy` container) |
| Robotic platform tested on | Synthetic scan source (scripted test), Gazebo TurtleBot3 (manual) |

---

## Description of contribution in a few bullet points

* Adds `PausedState::reset()` and calls it from `on_configure`, alongside the other per-session members reset there.
* Fixes #884: pause flags survived a `deactivate` → `cleanup` → `configure` cycle, so the node kept dropping scans while `paused_new_measurements` reported `false`.
* ABI-safe for a released distribution: `reset()` is a new non-virtual member defined in-class, and adds no data members. `PausedState`'s layout and every existing symbol are unchanged.

## How this was tested

A small node publishes `odom→base_footprint` on a circle and ray-cast `/scan` against a square room — no Gazebo, so the test is deterministic. The script then drives the exact reproduction from #884 and counts `/pose` (one message per accepted scan) in each phase:

1. `configure` → `activate`, count for 12 s — baseline, mapping
2. `pause_new_measurements`, count for 6 s — must be 0
3. `deactivate` → `cleanup` → `configure` → `activate`
4. read `paused_new_measurements`, count for 14 s from activation

Before: step 4 reads `false` and yields exactly 1 scan (the `first_measurement_` free pass), then nothing. After: `false` and mapping resumes.

Also confirmed manually — TurtleBot3 in Gazebo, same sequence driven by hand, map regrows after the lifecycle transitions on the fixed version and never changes on the original one.


## Description of documentation updates required from your changes

* None — no new parameters or interfaces.

---

## Future work that may be required in bullet points

* The same reset applies to `ros2`, `lyrical` and `kilted` — the `PausedState` and `on_configure` sources are unchanged across all four branches. Rolling PR to follow.
