### PR TITLE
[lyrical] Reset PausedState on lifecycle configure

### DIFF
--- a/include/slam_toolbox/toolbox_types.hpp
+++ b/include/slam_toolbox/toolbox_types.hpp
@@ -95,6 +95,13 @@ struct PausedState
 {
   PausedState()
   {
+    reset();
+  }
+
+  // Return every application to unpaused.
+  void reset()
+  {
+    boost::mutex::scoped_lock lock(pause_mutex_);
     state_map_[NEW_MEASUREMENTS] = false;
     state_map_[VISUALIZING_GRAPH] = false;
     state_map_[PROCESSING] = false;

--- a/src/slam_toolbox_common.cpp
+++ b/src/slam_toolbox_common.cpp
@@ -114,6 +114,9 @@ CallbackReturn SlamToolbox::on_configure(const rclcpp_lifecycle::State &)
   processor_type_ = PROCESS;
   first_measurement_ = true;
   process_near_pose_ = nullptr;
+  // Pause flags are per-session. Stale ones desync from the parameters
+  // republished below and by LoopClosureAssistant.
+  state_.reset();
   smapper_ = std::make_unique<mapper_utils::SMapper>();
   dataset_ = std::make_unique<Dataset>();
 


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses | #884 |
| Primary OS tested on | Ubuntu 26.04 (`ros:lyrical` container) |
| Robotic platform tested on | Synthetic scan source (scripted test) |

---

## Description of contribution in a few bullet points

* Cherry-pick of #886 onto `lyrical`, as requested there. The patch applies verbatim — `PausedState` and the `on_configure` block are identical between the two branches.
* Fixes #884. Rationale and the ABI notes are in #886.

## How this was tested

Same harness as #886, re-run on this branch against `ros:lyrical`. Unfixed `lyrical` stays silently paused after a `deactivate` → `cleanup` → `configure` → `activate` cycle; this branch resumes mapping.

## Description of documentation updates required from your changes

* None — no new parameters or interfaces.

---

## Future work that may be required in bullet points

* `kilted` carries the same unfixed code if you want that branch covered too.
