### PR TITLE
Transform initial poses consistently into the map frame

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -299,14 +299,27 @@ add_executable(merge_maps_kinematic src/merge_maps_kinematic.cpp)
 target_link_libraries(merge_maps_kinematic kartoSlamToolbox toolbox_common)
 
 #### testing
-#if(BUILD_TESTING)
-#  find_package(ament_cmake_gtest REQUIRED)
-#  find_package(ament_lint_auto REQUIRED)
-#  ament_lint_auto_find_test_dependencies()
-#  include_directories(test)
-#  ament_add_gtest(lifelong_metrics_test test/lifelong_metrics_test.cpp)
-#  target_link_libraries(lifelong_metrics_test lifelong_slam_toolbox)
-#endif()
+if(BUILD_TESTING)
+  find_package(ament_cmake_gtest REQUIRED)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+  include_directories(test)
+
+  ament_add_gtest(lifelong_metrics_test test/lifelong_metrics_test.cpp)
+  if(TARGET lifelong_metrics_test)
+    target_link_libraries(lifelong_metrics_test lifelong_slam_toolbox)
+  endif()
+
+  ament_add_gtest(initial_pose_utils_test test/initial_pose_utils_test.cpp)
+  if(TARGET initial_pose_utils_test)
+    target_link_libraries(initial_pose_utils_test
+      rclcpp::rclcpp
+      tf2::tf2
+      tf2_geometry_msgs::tf2_geometry_msgs
+      tf2_ros::tf2_ros
+    )
+  endif()
+endif()
 
 rclcpp_components_register_nodes(async_slam_toolbox "slam_toolbox::AsynchronousSlamToolbox")
 rclcpp_components_register_nodes(sync_slam_toolbox "slam_toolbox::SynchronousSlamToolbox")

--- a/include/slam_toolbox/initial_pose_utils.hpp
+++ b/include/slam_toolbox/initial_pose_utils.hpp
@@ -1,0 +1,55 @@
+#ifndef SLAM_TOOLBOX__INITIAL_POSE_UTILS_HPP_
+#define SLAM_TOOLBOX__INITIAL_POSE_UTILS_HPP_
+
+#include <string>
+
+#include "geometry_msgs/msg/pose_stamped.hpp"
+#include "geometry_msgs/msg/pose_with_covariance_stamped.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "tf2/exceptions.h"
+#include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
+#include "tf2/time.h"
+#include "tf2_ros/buffer_interface.h"
+
+namespace slam_toolbox
+{
+
+inline bool transformInitialPoseToFrame(
+  const geometry_msgs::msg::PoseWithCovarianceStamped & msg,
+  const std::string & target_frame,
+  tf2_ros::BufferInterface & tf_buffer,
+  const rclcpp::Logger & logger,
+  const char * callback_name,
+  geometry_msgs::msg::PoseStamped & pose_out)
+{
+  pose_out.header = msg.header;
+  pose_out.header.frame_id = target_frame;
+  pose_out.pose = msg.pose.pose;
+
+  if (msg.header.frame_id == target_frame) {
+    return true;
+  }
+
+  geometry_msgs::msg::PoseStamped pose_in;
+  pose_in.header = msg.header;
+  pose_in.pose = msg.pose.pose;
+
+  try {
+    tf_buffer.transform(pose_in, pose_out, target_frame, tf2::durationFromSec(0.5));
+  } catch (const tf2::TransformException & ex) {
+    RCLCPP_ERROR(
+      logger,
+      "%s: could not transform pose from %s to %s: %s",
+      callback_name,
+      msg.header.frame_id.c_str(),
+      target_frame.c_str(),
+      ex.what());
+    return false;
+  }
+
+  return true;
+}
+
+}  // namespace slam_toolbox
+
+#endif  // SLAM_TOOLBOX__INITIAL_POSE_UTILS_HPP_

--- a/rviz_plugin/slam_toolbox_rviz_plugin.cpp
+++ b/rviz_plugin/slam_toolbox_rviz_plugin.cpp
@@ -17,6 +17,7 @@
 /* Author: Steven Macenski */
 
 // Header
+#include "slam_toolbox/initial_pose_utils.hpp"
 #include "rviz_plugin/slam_toolbox_rviz_plugin.hpp"
 // ROS
 #include <tf2_ros/transform_listener.hpp>
@@ -266,21 +267,11 @@ void SlamToolboxPlugin::InitialPoseCallback(
     ros_node_->get_logger(),
     "Setting initial pose from rviz; you can now deserialize a map given that pose.");
   
-  // msg must be in map_frame_, so transform if msg arrived in a different frame
-  std::string fixed_frame = msg->header.frame_id;
-  geometry_msgs::msg::PoseStamped pose_in, pose_out;
-  pose_out.pose = msg->pose.pose;
-  if (fixed_frame != map_frame_) {
-    pose_in.header = msg->header;
-    pose_in.pose = msg->pose.pose;
-    try {
-      tf_buffer_->transform(pose_in, pose_out, map_frame_, tf2::durationFromSec(0.5));
-    } catch (const tf2::TransformException & ex) {
-      RCLCPP_ERROR(ros_node_->get_logger(),
-        "InitialPoseCallback: could not transform pose from %s to %s: %s",
-        msg->header.frame_id.c_str(), map_frame_.c_str(), ex.what());
-      return;
-    }
+  geometry_msgs::msg::PoseStamped pose_out;
+  if (!transformInitialPoseToFrame(
+      *msg, map_frame_, *tf_buffer_, ros_node_->get_logger(), "InitialPoseCallback", pose_out))
+  {
+    return;
   }
 
   _radio2->setChecked(true);

--- a/src/slam_toolbox_localization.cpp
+++ b/src/slam_toolbox_localization.cpp
@@ -18,6 +18,7 @@
 
 #include <memory>
 #include <string>
+#include "slam_toolbox/initial_pose_utils.hpp"
 #include "slam_toolbox/slam_toolbox_localization.hpp"
 
 namespace slam_toolbox
@@ -249,21 +250,11 @@ void LocalizationSlamToolbox::localizePoseCallback(
     return;
   }
 
-  // process_near_pose_ must be in map_frame_, so transform if msg arrived in a different frame
-  std::string fixed_frame = msg->header.frame_id;
-  geometry_msgs::msg::PoseStamped pose_in, pose_out;
-  pose_out.pose = msg->pose.pose;
-  if (fixed_frame != map_frame_) {
-    pose_in.header = msg->header;
-    pose_in.pose = msg->pose.pose;
-    try {
-      tf_->transform(pose_in, pose_out, map_frame_, tf2::durationFromSec(0.5));
-    } catch (const tf2::TransformException & ex) {
-      RCLCPP_ERROR(get_logger(),
-        "LocalizePoseCallback: could not transform pose from %s to %s: %s",
-        msg->header.frame_id.c_str(), map_frame_.c_str(), ex.what());
-      return;
-    }
+  geometry_msgs::msg::PoseStamped pose_out;
+  if (!transformInitialPoseToFrame(
+      *msg, map_frame_, *tf_, get_logger(), "LocalizePoseCallback", pose_out))
+  {
+    return;
   }
 
   boost::mutex::scoped_lock l(pose_mutex_);

--- a/test/initial_pose_utils_test.cpp
+++ b/test/initial_pose_utils_test.cpp
@@ -1,0 +1,91 @@
+#include <cmath>
+#include <memory>
+
+#include <gtest/gtest.h>
+
+#include "geometry_msgs/msg/transform_stamped.hpp"
+#include "slam_toolbox/initial_pose_utils.hpp"
+#include "tf2/LinearMath/Quaternion.h"
+#include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
+#include "tf2_ros/buffer.h"
+
+namespace slam_toolbox
+{
+namespace
+{
+
+constexpr double kHalfPi = 1.5707963267948966;
+
+geometry_msgs::msg::PoseWithCovarianceStamped makePoseMessage(
+  const std::string & frame_id,
+  double x,
+  double y,
+  double yaw)
+{
+  geometry_msgs::msg::PoseWithCovarianceStamped msg;
+  msg.header.frame_id = frame_id;
+  msg.pose.pose.position.x = x;
+  msg.pose.pose.position.y = y;
+
+  tf2::Quaternion orientation;
+  orientation.setRPY(0.0, 0.0, yaw);
+  msg.pose.pose.orientation = tf2::toMsg(orientation);
+  return msg;
+}
+
+TEST(InitialPoseUtilsTests, LeavesPoseUntouchedInTargetFrame)
+{
+  auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
+  tf2_ros::Buffer buffer(clock);
+  const auto msg = makePoseMessage("map", 1.25, -0.5, 0.3);
+
+  geometry_msgs::msg::PoseStamped pose_out;
+  EXPECT_TRUE(
+    transformInitialPoseToFrame(
+      msg, "map", buffer, rclcpp::get_logger("initial_pose_utils_test"), "test", pose_out));
+  EXPECT_DOUBLE_EQ(pose_out.pose.position.x, msg.pose.pose.position.x);
+  EXPECT_DOUBLE_EQ(pose_out.pose.position.y, msg.pose.pose.position.y);
+  EXPECT_NEAR(
+    tf2::getYaw(pose_out.pose.orientation),
+    tf2::getYaw(msg.pose.pose.orientation),
+    1e-9);
+}
+
+TEST(InitialPoseUtilsTests, TransformsPoseIntoTargetFrame)
+{
+  auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
+  tf2_ros::Buffer buffer(clock);
+
+  geometry_msgs::msg::TransformStamped transform;
+  transform.header.frame_id = "map";
+  transform.child_frame_id = "world";
+  transform.transform.translation.x = 1.0;
+  transform.transform.translation.y = 2.0;
+  transform.transform.translation.z = 0.0;
+  tf2::Quaternion rotation;
+  rotation.setRPY(0.0, 0.0, kHalfPi);
+  transform.transform.rotation = tf2::toMsg(rotation);
+  EXPECT_TRUE(buffer.setTransform(transform, "test", true));
+
+  const auto msg = makePoseMessage("world", 1.0, 0.0, 0.0);
+
+  geometry_msgs::msg::PoseStamped pose_out;
+  EXPECT_TRUE(
+    transformInitialPoseToFrame(
+      msg, "map", buffer, rclcpp::get_logger("initial_pose_utils_test"), "test", pose_out));
+  EXPECT_NEAR(pose_out.pose.position.x, 1.0, 1e-9);
+  EXPECT_NEAR(pose_out.pose.position.y, 3.0, 1e-9);
+  EXPECT_NEAR(tf2::getYaw(pose_out.pose.orientation), kHalfPi, 1e-9);
+}
+
+}  // namespace
+}  // namespace slam_toolbox
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  testing::InitGoogleTest(&argc, argv);
+  const int result = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return result;
+}


### PR DESCRIPTION
## Summary

- centralize initial-pose frame conversion in a self-contained helper
- use it from both the localization node and RViz plugin paths
- add regressions for an already-map-framed pose and a pose requiring a transform

## Why

The RViz initial-pose path could ignore the incoming pose frame and apply coordinates as though they were already in the map frame. Sharing the transform helper prevents the two code paths from drifting and fixes #863.

## Verification

- helper directly includes the `PoseStamped` tf2 specialization it uses
- test target wired into `BUILD_TESTING` with existing dependencies
- `git diff --check`

A compiled ROS/ament test run was not available on this host and remains CI-bound.

Fixes #863